### PR TITLE
WN-283

### DIFF
--- a/database/migrations/2025_03_18_151133_insert_values_into_organisations.php
+++ b/database/migrations/2025_03_18_151133_insert_values_into_organisations.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+class InsertValuesIntoOrganisations extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('organisations')->insert([
+            ['country_code' => 'GLB', 'org_name' => 'Global', 'oid_code' => 'urn:oid:2.49.0.4.1', 'attribution_url' => 'https://global.org/', 'attribution_file_name' => null],
+            ['country_code' => 'AMR', 'org_name' => 'Americas', 'oid_code' => 'urn:oid:2.49.0.4.2', 'attribution_url' => 'https://americas.org/', 'attribution_file_name' => null],
+            ['country_code' => 'APC', 'org_name' => 'Asia Pacific', 'oid_code' => 'urn:oid:2.49.0.4.3', 'attribution_url' => 'https://asiapacific.org/', 'attribution_file_name' => null],
+            ['country_code' => 'MNA', 'org_name' => 'MENA', 'oid_code' => 'urn:oid:2.49.0.4.4', 'attribution_url' => 'https://mena.org/', 'attribution_file_name' => null],
+            ['country_code' => 'EUR', 'org_name' => 'Europe', 'oid_code' => 'urn:oid:2.49.0.4.5', 'attribution_url' => 'https://europe.org/', 'attribution_file_name' => null],
+            ['country_code' => 'AFR', 'org_name' => 'Africa', 'oid_code' => 'urn:oid:2.49.0.4.6', 'attribution_url' => 'https://africa.org/', 'attribution_file_name' => null],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('organisations')
+            ->whereIn('country_code', ['GLB', 'AMR', 'APC', 'MNA', 'EUR', 'AFR'])
+            ->delete();
+    }
+}


### PR DESCRIPTION
Created database migration to add the following national societies:
- GLB, Global, urn:oid:2.49.0.4.1, https://global.org/
- AMR, Americas, urn:oid:2.49.0.4.2, https://americas.org/
- APC, Asia Pacific, urn:oid:2.49.0.4.3, https://asiapacific.org/
- MNA, MENA, urn:oid:2.49.0.4.4, https://mena.org/
- EUR, Europe, urn:oid:2.49.0.4.5, https://europe.org/
- AFR, Africa, urn:oid:2.49.0.4.6, https://africa.org/
