### PR TITLE
WN-280

### DIFF
--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -134,6 +134,7 @@
 
             requestInterceptor: function(request) {
                 request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                request.headers['Accept-Language'] = 'en';
                 return request;
             },
 


### PR DESCRIPTION
WN-280,
fix(swagger): force Accept-Language header to "en" to prevent DB errors
Swagger UI was automatically sending a long Accept-Language header (e.g., "en-US,en;q=0.5") which caused an SQL error due to column size limits in the usage_logs table.

This commit overrides the Swagger UI config to force the Accept-Language header to a fixed value ("en"), avoiding the issue entirely.

Modified the published Swagger UI view in resources/views/vendor/l5-swagger/index.blade.php.