### PR TITLE
feature/WN-285

### DIFF
--- a/app/Classes/Feeds/WhatNowFeed.php
+++ b/app/Classes/Feeds/WhatNowFeed.php
@@ -96,7 +96,7 @@ class WhatNowFeed implements JsonFeedInterface
 	 */
 	public function setRegion(Region $region = null)
 	{
-		$this->region = $region;
+		$this->subnational = $region;
 		return $this;
 	}
 
@@ -134,7 +134,7 @@ class WhatNowFeed implements JsonFeedInterface
 			$this->organisation->id,
 			$this->language,
 			$this->filterEventTypes,
-			$this->region->id ?? null
+			$this->subnational->id ?? null
 		);
 
 		if ($data instanceof Collection) {

--- a/app/Classes/Transformers/WhatNowEntityTransformer.php
+++ b/app/Classes/Transformers/WhatNowEntityTransformer.php
@@ -64,7 +64,7 @@ class WhatNowEntityTransformer extends TransformerAbstract
 			'countryCode' => $model->organisation->country_code,
 			'eventType' => $model->event_type,
             'regionName' => $model->region_name,
-            'region' => $model->region,
+            'subnational' => $model->subnational,
 			'attribution' => [
 				'name' => $model->organisation->org_name,
 				'countryCode' => $model->organisation->country_code,

--- a/app/Http/Controllers/RegionController.php
+++ b/app/Http/Controllers/RegionController.php
@@ -39,17 +39,17 @@ class RegionController extends Controller
 
     /**
      * @OA\Post(
-     *     path="/regions",
+     *     path="/subnationals",
      *     tags={"Regions"},
-     *     summary="Create a new region",
+     *     summary="Create a new subnational",
      *     operationId="createRegion",
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
      *             required={"countryCode", "title"},
      *             @OA\Property(property="countryCode", type="string", example="USA", description="Country code (3 characters)"),
-     *             @OA\Property(property="title", type="string", example="North America", description="Title of the region"),
-     *             @OA\Property(property="slug", type="string", example="north-america", description="Slug for the region (optional)"),
+     *             @OA\Property(property="title", type="string", example="North America", description="Title of the subnational"),
+     *             @OA\Property(property="slug", type="string", example="north-america", description="Slug for the subnational (optional)"),
      *             @OA\Property(
      *                 property="translations",
      *                 type="array",
@@ -58,7 +58,7 @@ class RegionController extends Controller
      *                     @OA\Property(property="webUrl", type="string", format="url", example="https://example.com", description="Web URL for the translation"),
      *                     @OA\Property(property="lang", type="string", example="en", description="Language code (2 characters)"),
      *                     @OA\Property(property="title", type="string", example="North America", description="Title in the specified language"),
-     *                     @OA\Property(property="description", type="string", example="Description of the region", description="Description in the specified language")
+     *                     @OA\Property(property="description", type="string", example="Description of the subnational", description="Description in the specified language")
      *                 )
      *             )
      *         )
@@ -103,10 +103,10 @@ class RegionController extends Controller
         }
 
         $slug = empty($request->input('slug')) ? str_slug($request->input('title')) : $request->input('slug');
-        $existing = $org->regions()->where('slug', '=', $request->input('slug'))->count();
+        $existing = $org->subnationals()->where('slug', '=', $request->input('slug'))->count();
 
         if ($existing > 0) {
-            return response()->json([ 'error_message' => 'This region already exists', 'errors' => []], 409);
+            return response()->json([ 'error_message' => 'This subnational already exists', 'errors' => []], 409);
         }
 
         $region = Region::create([
@@ -128,22 +128,22 @@ class RegionController extends Controller
 
     /**
      * @OA\Put(
-     *     path="/regions/region/{regionId}",
+     *     path="/subnationals/subnational/{regionId}",
      *     tags={"Regions"},
-     *     summary="Update an existing region",
+     *     summary="Update an existing subnational",
      *     operationId="updateRegion",
      *     @OA\Parameter(
      *         name="regionId",
      *         in="path",
      *         required=true,
-     *         description="ID of the region to update",
+     *         description="ID of the subnational to update",
      *         @OA\Schema(type="integer", format="int64")
      *     ),
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
-     *             @OA\Property(property="title", type="string", example="Updated Region Title", description="Updated title of the region (optional)"),
-     *             @OA\Property(property="slug", type="string", example="updated-region-slug", description="Updated slug for the region (optional)"),
+     *             @OA\Property(property="title", type="string", example="Updated Region Title", description="Updated title of the subnational (optional)"),
+     *             @OA\Property(property="slug", type="string", example="updated-subnational-slug", description="Updated slug for the subnational (optional)"),
      *             @OA\Property(
      *                 property="translations",
      *                 type="array",
@@ -172,7 +172,7 @@ class RegionController extends Controller
         $region = Region::find($regionId);
 
         if (empty($region)) {
-            return response()->json([ 'error_message' => 'No region found', 'errors' => []], 404);
+            return response()->json([ 'error_message' => 'No subnational found', 'errors' => []], 404);
         }
 
         $this->validate($request, [
@@ -216,8 +216,8 @@ class RegionController extends Controller
 
     /**
      * @OA\Get(
-     *     path="/regions/{country_code}",
-     *     summary="Get all regions for a specific organisation by country code",
+     *     path="/subnationals/{country_code}",
+     *     summary="Get all subnationals for a specific organisation by country code",
      *     tags={"Regions"},
      *     @OA\Parameter(
      *         name="country_code",
@@ -248,7 +248,7 @@ class RegionController extends Controller
         }
 
         $list = [];
-        foreach ($organisation->regions as $region) {
+        foreach ($organisation->subnationals as $region) {
             $data = [
                 'id' => $region->id,
                 'title' => $region->title,
@@ -270,8 +270,8 @@ class RegionController extends Controller
 
     /**
      * @OA\Get(
-     *     path="/regions/{country_code}/{code}",
-     *     summary="Get regions for a specific organisation by country code and language code",
+     *     path="/subnationals/{country_code}/{code}",
+     *     summary="Get subnationals for a specific organisation by country code and language code",
      *     tags={"Regions"},
      *     @OA\Parameter(
      *         name="country_code",
@@ -309,7 +309,7 @@ class RegionController extends Controller
         }
 
         $list = [];
-        foreach ($organisation->regions as $region) {
+        foreach ($organisation->subnationals as $region) {
             $translation = $region->translations()
                 ->where('language_code', '=', $code)
                 ->first();
@@ -329,15 +329,15 @@ class RegionController extends Controller
 
     /**
      * @OA\Delete(
-     *     path="/regions/region/{regionId}",
+     *     path="/subnationals/subnational/{regionId}",
      *     tags={"Regions"},
-     *     summary="Delete a region",
+     *     summary="Delete a subnational",
      *     operationId="deleteRegion",
      *     @OA\Parameter(
      *         name="regionId",
      *         in="path",
      *         required=true,
-     *         description="ID of the region to delete",
+     *         description="ID of the subnational to delete",
      *         @OA\Schema(type="integer", format="int64")
      *     ),
      *     @OA\Response(
@@ -355,7 +355,7 @@ class RegionController extends Controller
         $region = Region::find($regionId);
 
         if (empty($region)) {
-            return response()->json([ 'error_message' => 'No region found', 'errors' => []], 404);
+            return response()->json([ 'error_message' => 'No subnational found', 'errors' => []], 404);
         }
 
         $keys = $region->translations()->pluck('id')->toArray();
@@ -368,9 +368,9 @@ class RegionController extends Controller
 
     /**
      * @OA\Delete(
-     *     path="/regions/region/translation/{translationId}",
+     *     path="/subnationals/subnational/translation/{translationId}",
      *     tags={"Regions"},
-     *     summary="Delete a region translation",
+     *     summary="Delete a subnational translation",
      *     operationId="deleteTranslation",
      *     @OA\Parameter(
      *         name="translationId",

--- a/app/Http/Controllers/UsageLogController.php
+++ b/app/Http/Controllers/UsageLogController.php
@@ -314,10 +314,10 @@ class UsageLogController extends Controller
      *         @OA\Schema(type="string")
      *     ),
      *     @OA\Parameter(
-     *         name="region",
+     *         name="subnational",
      *         in="query",
      *         required=false,
-     *         description="Filter by region ID",
+     *         description="Filter by subnational ID",
      *         @OA\Schema(type="integer")
      *     ),
      *     @OA\Parameter(
@@ -355,7 +355,7 @@ class UsageLogController extends Controller
     {
         $this->validate($request, [
             'society' => 'sometimes|string',
-            'region' => 'sometimes|int',
+            'subnational' => 'sometimes|int',
             'hazard' => 'sometimes|string',
             'date' => 'sometimes|date',
             'language' => 'sometimes|string',
@@ -368,8 +368,8 @@ class UsageLogController extends Controller
             if (isset($request->society)) {
                 $query->where('endpoint', 'v1/org/'.$request->society.'/whatnow');
             }
-            if (isset($request->region)) {
-                $query->where('region', $request->region);
+            if (isset($request->subnational)) {
+                $query->where('subnational', $request->subnational);
             }
             if (isset($request->hazard)) {
                 $query->where('event_type', 'like', '%' . $request->hazard . '%');

--- a/app/Http/Controllers/WhatNowController.php
+++ b/app/Http/Controllers/WhatNowController.php
@@ -271,10 +271,10 @@ class WhatNowController extends Controller
      *         @OA\Schema(type="string")
      *     ),
      *     @OA\Parameter(
-     *         name="region",
+     *         name="subnational",
      *         in="query",
      *         required=false,
-     *         description="Filter by region slug",
+     *         description="Filter by subnational slug",
      *         @OA\Schema(type="string")
      *     ),
      *     @OA\Parameter(
@@ -313,7 +313,7 @@ class WhatNowController extends Controller
             }
             $feed->setOrganisation($org);
 
-            $regName = $this->request->query('region', null);
+            $regName = $this->request->query('subnational', null);
             if ($regName) {
                 try {
                     $reg = $this->regionRepo->findBySlug($org->id, $regName);
@@ -412,9 +412,9 @@ class WhatNowController extends Controller
      */
     /**
      * @OA\Get(
-     *     path="/org/{code}/{region}/whatnow/revisions/latest",
+     *     path="/org/{code}/{subnational}/whatnow/revisions/latest",
      *     tags={"Whatnow"},
-     *     summary="Get the latest revisions for a specific region",
+     *     summary="Get the latest revisions for a specific subnational",
      *     operationId="getLatestForRegion",
      *     @OA\Parameter(
      *         name="code",
@@ -424,7 +424,7 @@ class WhatNowController extends Controller
      *         @OA\Schema(type="string")
      *     ),
      *     @OA\Parameter(
-     *         name="region",
+     *         name="subnational",
      *         in="path",
      *         required=true,
      *         description="Region slug to fetch the latest revisions for",
@@ -451,7 +451,7 @@ class WhatNowController extends Controller
         }
 
         try {
-            $region = $org->regions()->where('slug', str_slug($region))->firstOrFail();
+            $region = $org->subnationals()->where('slug', str_slug($region))->firstOrFail();
         } catch (\Exception $e) {
             Log::error('Organisation not found', ['message' => $e->getMessage()]);
 
@@ -507,7 +507,7 @@ class WhatNowController extends Controller
      *             required={"countryCode", "eventType", "translations"},
      *             @OA\Property(property="countryCode", type="string", example="USA", description="Country code (3 characters)"),
      *             @OA\Property(property="eventType", type="string", example="Flood", description="Type of event (max 50 characters)"),
-     *             @OA\Property(property="regionName", type="string", example="North Region", description="Name of the region (optional)"),
+     *             @OA\Property(property="regionName", type="string", example="North Region", description="Name of the subnational (optional)"),
      *             @OA\Property(
      *                 property="translations",
      *                 type="array",
@@ -574,7 +574,7 @@ class WhatNowController extends Controller
                 return response()->json([
                     'status' => 500,
                     'error_message' => 'Unable to create item',
-                    'errors' => ['No matching region for country code'],
+                    'errors' => ['No matching subnational for country code'],
                 ], 500);
             }
         }
@@ -642,7 +642,7 @@ class WhatNowController extends Controller
      *             required={"countryCode", "eventType", "translations"},
      *             @OA\Property(property="countryCode", type="string", example="USA", description="Country code (3 characters)"),
      *             @OA\Property(property="eventType", type="string", example="Flood", description="Type of event (max 50 characters)"),
-     *             @OA\Property(property="regionName", type="string", example="North Region", description="Name of the region (optional)"),
+     *             @OA\Property(property="regionName", type="string", example="North Region", description="Name of the subnational (optional)"),
      *             @OA\Property(
      *                 property="translations",
      *                 type="array",
@@ -718,7 +718,7 @@ class WhatNowController extends Controller
                 return response()->json([
                     'status' => 500,
                     'error_message' => 'Unable to create item',
-                    'errors' => ['No matching region for country code'],
+                    'errors' => ['No matching subnational for country code'],
                 ], 500);
             }
         }

--- a/app/Http/Middleware/ApiAuthMiddleware.php
+++ b/app/Http/Middleware/ApiAuthMiddleware.php
@@ -31,7 +31,7 @@ class ApiAuthMiddleware extends BasicAuthMiddleware
         $usageLog->timestamp = Carbon::now()->toDateTimeString();
         $usageLog->code_status = 200;
         $usageLog->language = $request->input('language', false) ? $request->input('language', null) : $request->header('Accept-Language', null);
-        $usageLog->region = $request->input('region', null);
+        $usageLog->subnational = $request->input('subnational', null);
         $usageLog->event_type = $request->input('eventType', null);
         $usageLog->save();
         $request->usageLog=$usageLog;

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -37,7 +37,7 @@ class Organisation extends Model
 		return $this->hasMany('App\Models\OrganisationDetails', 'org_id');
 	}
 
-    public function regions()
+    public function subnationals()
     {
         return $this->hasMany(Region::class);
     }

--- a/app/Models/Region.php
+++ b/app/Models/Region.php
@@ -12,7 +12,7 @@ class Region extends Model
      *
      * @var string
      */
-    protected $table = 'regions';
+    protected $table = 'subnationals';
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/RegionTranslation.php
+++ b/app/Models/RegionTranslation.php
@@ -38,7 +38,7 @@ class RegionTranslation extends Model
     ];
 
 
-    public function region()
+    public function subnational()
     {
         return $this->belongsTo(Region::class);
     }

--- a/app/Models/WhatNowEntity.php
+++ b/app/Models/WhatNowEntity.php
@@ -100,7 +100,7 @@ class WhatNowEntity extends Model
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function region()
+    public function subnational()
     {
         return $this->belongsTo('App\Models\Region', 'region_id', 'id');
     }
@@ -111,11 +111,11 @@ class WhatNowEntity extends Model
      */
     public function getRegionNameAttribute()
     {
-        if(empty($this->region)){
+        if(empty($this->subnational)){
             return 'National';
         }
 
-        return $this->region->title;
+        return $this->subnational->title;
     }
 
 	/**

--- a/app/Models/WhatNowEntityTranslation.php
+++ b/app/Models/WhatNowEntityTranslation.php
@@ -99,11 +99,11 @@ class WhatNowEntityTranslation extends Model
 
 //    public function getRegionNameAttribute()
 //    {
-//        if(empty($this->entity->region)){
+//        if(empty($this->entity->subnational)){
 //            return '';
 //        }
 //
-//        return $this->entity->region->title;
+//        return $this->entity->subnational->title;
 //    }
 
 	/**

--- a/config/cache.php
+++ b/config/cache.php
@@ -80,7 +80,7 @@ return [
             'driver' => 'dynamodb',
             'key' => env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
-            'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+            'subnational' => env('AWS_DEFAULT_REGION', 'us-east-1'),
             'table' => env('DYNAMODB_CACHE_TABLE', 'cache'),
             'endpoint' => env('DYNAMODB_ENDPOINT'),
         ],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -59,7 +59,7 @@ return [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
-            'region' => env('AWS_DEFAULT_REGION'),
+            'subnational' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
         ],

--- a/config/logging.php
+++ b/config/logging.php
@@ -69,7 +69,7 @@ return [
             'stream_name' => env('CW_STREAM', 'access-log'),
             'group_name' => env('CW_LOG_GROUP', 'whatnow-log'),
             'sdk' => [
-                'region' => 'eu-west-1',
+                'subnational' => 'eu-west-1',
                 'version' => 'latest',
                 'credentials' => [
                     'key' => env('AWS_CW_ACCESS'),

--- a/config/queue.php
+++ b/config/queue.php
@@ -55,7 +55,7 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'prefix' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
             'queue' => env('SQS_QUEUE', 'your-queue-name'),
-            'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+            'subnational' => env('AWS_DEFAULT_REGION', 'us-east-1'),
         ],
 
         'redis' => [

--- a/config/services.php
+++ b/config/services.php
@@ -27,7 +27,7 @@ return [
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
-        'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+        'subnational' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
 ];

--- a/database/migrations/2022_10_03_101726_create_regions_table.php
+++ b/database/migrations/2022_10_03_101726_create_regions_table.php
@@ -12,7 +12,7 @@ class CreateRegionsTable extends Migration
      */
     public function up()
     {
-        Schema::create('regions', function (Blueprint $table) {
+        Schema::create('subnationals', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('organisation_id')->unsigned()->index();
             $table->string('title');
@@ -40,7 +40,7 @@ class CreateRegionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('regions');
+        Schema::drop('subnationals');
         Schema::drop('region_translations');
     }
 }

--- a/database/migrations/2025_02_06_195052_add_code_status_on_usage_logs_table.php
+++ b/database/migrations/2025_02_06_195052_add_code_status_on_usage_logs_table.php
@@ -16,7 +16,7 @@ class AddCodeStatusOnUsageLogsTable extends Migration
         Schema::table('usage_logs', function (Blueprint $table) {
             $table->integer('code_status')->nullable();
             $table->string('language',10)->nullable();
-            $table->string('region',45)->nullable();
+            $table->string('subnational',45)->nullable();
             $table->string('event_type',45)->nullable();
         });
     }
@@ -31,7 +31,7 @@ class AddCodeStatusOnUsageLogsTable extends Migration
         Schema::table('usage_logs', function (Blueprint $table) {
             $table->dropColumn('code_status');
             $table->dropColumn('language');
-            $table->dropColumn('region');
+            $table->dropColumn('subnational');
             $table->dropColumn('event_type');
         });
     }

--- a/database/seeds/WhatNowTableSeeder.php
+++ b/database/seeds/WhatNowTableSeeder.php
@@ -63,14 +63,14 @@ class WhatNowTableSeeder extends Seeder
 
 		}
 
-        $path = dirname(__FILE__) . '/regions.csv';
+        $path = dirname(__FILE__) . '/subnationals.csv';
 
         $file = new SplFileObject($path);;
         $file->setFlags(SplFileObject::SKIP_EMPTY | SplFileObject::READ_AHEAD | SplFileObject::DROP_NEW_LINE | SplFileObject::READ_CSV);
         $timestamp = \Carbon\Carbon::now();
 
         foreach ($file as $row) {
-            DB::table('regions')->insert([
+            DB::table('subnationals')->insert([
                 'id' => $row[0],
                 'organisation_id' => $row[1],
                 'title' => $row[2],

--- a/database/seeds/alerts.csv
+++ b/database/seeds/alerts.csv
@@ -72,7 +72,7 @@ issued at 11:00 a.m., 15 september 2016
 typhoon ""gener"" has maintained its strength as it moves over the philippine sea.
 estimated rainfall amount is from moderate to heavy within the 400 km diameter of the typhoon.
 location of eye/center: (as of 10:00 a.m.) 735 km east of tuguegarao city
-maximum sustained winds of up to 130 kph near the center 
+maximum sustained winds of up to 130 kph near the center
 and gustiness of up to 160 kph.
 forecast to move  west northwest at 23 kph.
 24 hour(tomorrow morning):
@@ -90,10 +90,10 @@ forecast to move  west northwest at 23 kph.
 72,159,0,CAN,en,general notifications,test,test,"{""type"":""Polygon"",""coordinates"":[[[-14.765625,-6.2279339302687],[-14.9853515625,-3.7765593098769],[-11.689453125,-3.7765593098769],[-12.392578125,-6.2716180643149],[-14.765625,-6.2279339302687]]]}",test,alert,test,public,geo,immediate,moderate,unlikely,2016-09-21 10:44:55,2016-09-21 23:00:00,2016-09-20 23:00:00,2016-09-22 23:00:00,2016-09-21 10:43:10,2016-09-21 10:43:10
 73,96,0,NZL,en,general notifications,auckland test,"[auckland cdem] test public message for sunday by auckland cdem
 this is a test message by auckland civil defence and emergency management as part of our twice yearly checks of all public alerting systems, including email, sms, social media and the 44 fixed tsunami warning sirens across rodney and waitakere areas.
-  
-you will receive alerts from auckland civil defence when we need you to be aware of an emergency and take action.  
 
-sign up to our sms and email updates by visiting www.aucklandicivildefence.org.nz and clicking on subscribe.  
+you will receive alerts from auckland civil defence when we need you to be aware of an emergency and take action.
+
+sign up to our sms and email updates by visiting www.aucklandicivildefence.org.nz and clicking on subscribe.
 
 the next test of this system will take place on 2nd april 2017.","{""type"":""Polygon"",""coordinates"":[[[165.82763671875,-50.457504020421],[166.376953125,-50.443513052458],[166.4208984375,-50.986098933394],[165.849609375,-51.027576337802],[165.82763671875,-50.457504020421]]]}",auckland islands,alert,test,public,geo,immediate,extreme,observed,2016-09-23 05:42:40,2016-09-23 05:58:00,2016-09-23 05:50:00,2016-09-23 06:10:00,2016-09-23 05:40:55,2016-09-23 05:40:55
 74,165,0,PHL,en,general notifications,6.5 earthquake hit 41km se of mati (davao oriental),"[philippines red cross] what: 6.5 earthquake
@@ -105,9 +105,9 @@ tectonic in nature
 
 no tsunami alert reported as of this time from noaa and phivolcs
 
-reported intensities: 
+reported intensities:
 intensity v - mati, davao oriental; davao city
-intensity iv - general santos city; alabel, glan & malapatan, sarangani; polomolok, south 
+intensity iv - general santos city; alabel, glan & malapatan, sarangani; polomolok, south
 cotabato
 intensity iii - tupi, south cotabato; cagayan de oro city
 
@@ -115,12 +115,12 @@ no expected damage but with aftershocks
 
 source: phivolcs
 ","{""type"":""Polygon"",""coordinates"":[[[126.39770507812,6.3917304854815],[126.50756835938,7.0572823529716],[125.16723632812,7.5367643220841],[125.01342773438,5.8346161656101],[125.49682617188,5.5175752008306],[126.39770507812,6.3917304854815]]]}",041 km s 40° e of mati (davao oriental),alert,actual,public,geo,immediate,minor,observed,2016-09-23 23:59:03,2016-09-24 16:00:00,2016-09-23 16:00:00,2016-09-25 16:00:00,2016-09-23 23:57:04,2016-09-23 23:57:04
-75,96,0,NZL,en,general notifications,***test only. no action required***,"[auckland cdem] this is a test message from auckland civil defence and emergency management.  we test all alerting systems twice yearly on daylight savings. 
+75,96,0,NZL,en,general notifications,***test only. no action required***,"[auckland cdem] this is a test message from auckland civil defence and emergency management.  we test all alerting systems twice yearly on daylight savings.
 
 you can sign up to receive emergency alerts via text and email by visiting www.aucklandicivildefence.org.nz.
 
 make sure you tell your family and friends to sign up to receive emergency alerts too.
-","{""type"":""Polygon"",""coordinates"":[[[174.74853515625,-37.596824001084],[174.91882324219,-37.553287645958],[175.02319335938,-37.4443354462],[175.07263183594,-37.391981943534],[175.05615234375,-37.317751851637],[175.10559082031,-37.274052809979],[175.17150878906,-37.239075302022],[175.22094726562,-37.186578595249],[175.27587890625,-37.125286284967],[175.33081054688,-37.094621500156],[175.30334472656,-36.778492404594],[175.19348144531,-36.456636011596],[175.33081054688,-36.354951106435],[175.54504394531,-36.403599620733],[175.77026367188,-36.284135327417],[175.67687988281,-36.075742215627],[175.46264648438,-35.978006180856],[175.23742675781,-35.960222969297],[175.01770019531,-36.057981047025],[174.76501464844,-36.120127589781],[174.61669921875,-36.155617833819],[174.51782226562,-36.208823092837],[174.42993164062,-36.261992204457],[174.32556152344,-36.328402729423],[174.18273925781,-36.403599620733],[174.05639648438,-36.505220863384],[174.74853515625,-37.596824001084]]]}",auckland region,alert,actual,public,geo,immediate,extreme,observed,2016-09-24 23:08:02,2016-09-24 23:00:00,2016-09-24 23:00:00,2016-09-25 01:00:00,2016-09-24 23:06:07,2016-09-24 23:06:07
+","{""type"":""Polygon"",""coordinates"":[[[174.74853515625,-37.596824001084],[174.91882324219,-37.553287645958],[175.02319335938,-37.4443354462],[175.07263183594,-37.391981943534],[175.05615234375,-37.317751851637],[175.10559082031,-37.274052809979],[175.17150878906,-37.239075302022],[175.22094726562,-37.186578595249],[175.27587890625,-37.125286284967],[175.33081054688,-37.094621500156],[175.30334472656,-36.778492404594],[175.19348144531,-36.456636011596],[175.33081054688,-36.354951106435],[175.54504394531,-36.403599620733],[175.77026367188,-36.284135327417],[175.67687988281,-36.075742215627],[175.46264648438,-35.978006180856],[175.23742675781,-35.960222969297],[175.01770019531,-36.057981047025],[174.76501464844,-36.120127589781],[174.61669921875,-36.155617833819],[174.51782226562,-36.208823092837],[174.42993164062,-36.261992204457],[174.32556152344,-36.328402729423],[174.18273925781,-36.403599620733],[174.05639648438,-36.505220863384],[174.74853515625,-37.596824001084]]]}",auckland subnational,alert,actual,public,geo,immediate,extreme,observed,2016-09-24 23:08:02,2016-09-24 23:00:00,2016-09-24 23:00:00,2016-09-25 01:00:00,2016-09-24 23:06:07,2016-09-24 23:06:07
 76,96,0,NZL,en,general notifications,fire,[auckland cdem] auckland cdem is monitoring an incident in the henderson area where there is a factory fire.  please stay away from the area and remain indoors and windows closed if you are nearby.  auckland civil defence.  ,"{""type"":""Polygon"",""coordinates"":[[[174.61051940918,-36.876050419425],[174.62356567383,-36.860669250539],[174.65789794922,-36.910646725646],[174.62459564209,-36.917783694111],[174.61051940918,-36.876050419425]]]}",henderson,alert,actual,public,geo,immediate,extreme,observed,2016-09-27 09:51:19,2016-09-27 09:00:00,2016-09-27 09:45:00,2016-09-27 14:00:00,2016-09-27 09:49:19,2016-09-27 09:49:19
 77,96,0,NZL,en,general notifications,thunderstorms in the south auckland ,[auckland cdem] thunderstorms in the south auckland area are causing localised flooding.  please drive to the conditions.  auckland cdem is monitoring the situation at this time.  ,"{""type"":""Polygon"",""coordinates"":[[[174.52194213867,-37.112145754752],[174.51782226562,-37.059560830251],[174.55902099609,-37.02777309665],[174.6125793457,-37.028869446965],[174.69360351562,-37.017905231731],[174.8762512207,-36.932330061503],[174.97375488281,-36.876325055012],[175.04928588867,-36.859845171961],[175.13580322266,-36.901587303978],[175.25802612305,-36.946599271636],[175.35278320312,-37.019001724461],[175.34866333008,-37.113240886049],[175.25802612305,-37.155938651245],[175.20034790039,-37.205175356203],[175.13580322266,-37.246728019617],[175.07675170898,-37.283887307614],[175.01083374023,-37.322120359452],[174.92156982422,-37.370157184058],[174.66888427734,-37.457418102629],[174.52194213867,-37.112145754752]]]}",south auckland area,alert,actual,public,geo,immediate,extreme,observed,2016-09-28 04:20:41,2016-09-28 04:15:00,2016-09-28 04:10:00,2016-09-30 09:00:00,2016-09-28 04:18:47,2016-09-28 04:18:47
 78,64,0,JAM,en,hurricane watch,hurricane watch issued for jamaica,breaking: #hurricanematthew is now a category 4 storm and is heading straight for jamaica. the island is now under a hurricane watch,"{""type"":""Polygon"",""coordinates"":[[[-78.9697265625,18.687878686034],[-75.9814453125,18.729501999072],[-75.9814453125,17.350638376049],[-79.1015625,17.476432197196],[-78.9697265625,18.687878686034]]]}",jamaica,alert,actual,public,geo,immediate,extreme,observed,2016-09-30 22:28:58,2016-10-01 05:00:00,2016-09-30 05:00:00,2016-10-02 05:00:00,2016-09-30 22:27:14,2016-09-30 22:27:14
@@ -129,17 +129,17 @@ make sure you tell your family and friends to sign up to receive emergency alert
 81,64,0,JAM,en,hurricane watch,update: hurricane matthew is now a category 5 storm,hurricane matthew has been upgraded to a category 5 storm. this makes it the first cat 5 storm since 2007. it is expected to make landfall in jamaica late sunday night into early monday morning. ,"{""type"":""Polygon"",""coordinates"":[[[-78.92578125,18.729501999072],[-75.673828125,18.646245142671],[-75.8935546875,17.392579271058],[-79.2333984375,17.350638376049],[-78.92578125,18.729501999072]]]}",jamaica,alert,actual,public,met,immediate,extreme,observed,2016-10-01 03:41:25,2016-10-01 05:00:00,2016-09-30 05:00:00,2016-10-02 05:00:00,2016-10-01 03:39:29,2016-10-01 03:39:29
 82,96,0,NZL,en,general notifications,*****test******,[nzrc test] *****test message*******,"{""type"":""Polygon"",""coordinates"":[[[165.96771240234,-50.481978259973],[165.70953369141,-50.941123218673],[166.42913818359,-50.998200340935],[166.34674072266,-50.399764609144],[165.96771240234,-50.481978259973]]]}",******test******** auckland island,alert,test,public,geo,immediate,extreme,observed,2016-10-03 00:47:13,2016-10-03 11:00:00,2016-10-03 01:00:00,2016-10-03 11:00:00,2016-10-03 00:45:16,2016-10-03 00:45:16
 83,64,0,JAM,en,hurricane warning,jamaica still under hurricane warning,a hurricane warning is still in effect for jamaica. please stay indoors even if you are not experiencing hurricane conditions in your area right now. ,"{""type"":""Polygon"",""coordinates"":[[[-78.662109375,19.062117883515],[-75.9375,19.062117883515],[-75.8935546875,17.098792237679],[-79.189453125,17.140790393317],[-78.662109375,19.062117883515]]]}",jamaica,alert,actual,public,met,immediate,extreme,observed,2016-10-03 21:40:27,2016-10-03 05:00:00,2016-10-03 05:00:00,2016-10-04 05:00:00,2016-10-03 21:38:27,2016-10-03 21:38:27
-84,96,0,NZL,en,general notifications,weather advisory,"[auckland cdem] metservice have advised there is a high risk of thunderstorms bringing heavy rain and strong winds for the auckland region tomorrow morning and late evening.
- 
+84,96,0,NZL,en,general notifications,weather advisory,"[auckland cdem] metservice have advised there is a high risk of thunderstorms bringing heavy rain and strong winds for the auckland subnational tomorrow morning and late evening.
+
 with soils already fully saturated there is chance of localised flooding and slips. check to ensure drains are clear. strong wind gusts may cause structural damage, including trees and power lines.
 
-please drive to the conditions and take care on the roads especially in slip prone areas. 
+please drive to the conditions and take care on the roads especially in slip prone areas.
 
-see metservice for additional information http://metservice.com/warnings/severe-weather-watch 
-","{""type"":""Polygon"",""coordinates"":[[[174.5947265625,-37.415981841946],[175.21820068359,-37.155938651245],[175.15777587891,-37.042024416351],[175.33905029297,-36.980615065286],[175.19622802734,-36.496389520004],[175.34729003906,-36.396967524418],[175.81146240234,-36.321764221204],[175.51483154297,-35.882374337292],[174.61669921875,-36.095718736555],[174.0234375,-36.474306755095],[174.5947265625,-37.415981841946]]]}",auckland region,alert,actual,public,geo,immediate,moderate,likely,2016-10-05 03:01:18,2016-10-05 03:00:00,2016-10-05 03:00:00,2016-10-06 10:55:00,2016-10-05 02:59:18,2016-10-05 02:59:18
+see metservice for additional information http://metservice.com/warnings/severe-weather-watch
+","{""type"":""Polygon"",""coordinates"":[[[174.5947265625,-37.415981841946],[175.21820068359,-37.155938651245],[175.15777587891,-37.042024416351],[175.33905029297,-36.980615065286],[175.19622802734,-36.496389520004],[175.34729003906,-36.396967524418],[175.81146240234,-36.321764221204],[175.51483154297,-35.882374337292],[174.61669921875,-36.095718736555],[174.0234375,-36.474306755095],[174.5947265625,-37.415981841946]]]}",auckland subnational,alert,actual,public,geo,immediate,moderate,likely,2016-10-05 03:01:18,2016-10-05 03:00:00,2016-10-05 03:00:00,2016-10-06 10:55:00,2016-10-05 02:59:18,2016-10-05 02:59:18
 85,96,0,NZL,en,severe weather statement,test message - severe weather statement - test message,[auckland cdem] test message - severe weather statement - test message,"{""type"":""Polygon"",""coordinates"":[[[166.31378173828,-50.481978259973],[166.0432434082,-50.53001578174],[165.85922241211,-50.807670394378],[166.05560302734,-50.9419885469],[166.26571655273,-50.83716687846],[166.31378173828,-50.481978259973]]]}",test message,alert,test,public,safety,immediate,extreme,observed,2016-10-05 19:12:10,2016-10-05 19:10:00,2016-10-05 19:10:00,2016-10-05 19:30:00,2016-10-05 19:10:12,2016-10-05 19:10:12
 86,96,0,NZL,en,general notifications,test message sent by wremo ,[wremo] **********wremo test**********,"{""type"":""Polygon"",""coordinates"":[[[166.23413085938,-50.212064460654],[165.86059570312,-50.527396813293],[165.65185546875,-50.951506094482],[166.30004882812,-51.172455303299],[166.44287109375,-50.896103955544],[166.49780273438,-50.632042188842],[166.58569335938,-50.450509053587],[166.23413085938,-50.212064460654]]]}",auckland islands,alert,test,public,geo,immediate,minor,observed,2016-10-06 00:24:25,2016-10-06 11:00:00,2016-10-05 11:00:00,2016-10-07 11:00:00,2016-10-06 00:22:18,2016-10-06 00:22:18
-87,96,0,NZL,en,general notifications,severe thunderstorm,[auckland cdem] a significant thunderstorm activity and rain and wind is starting to occur in this region.  if you have significant thunderstorms where you are please stay inside and away from windows.  auckland civil defence is monitoring this event.  ,"{""type"":""Polygon"",""coordinates"":[[[174.31182861328,-36.732280756072],[174.91058349609,-36.660707868219],[174.94079589844,-36.517362315727],[174.93118286133,-36.371539245849],[174.6826171875,-36.41023115104],[174.19647216797,-36.414651856777],[174.09210205078,-36.482036438804],[174.31182861328,-36.732280756072]]]}",auckland north,alert,actual,public,geo,immediate,extreme,observed,2016-10-06 07:27:31,2016-10-06 07:25:00,2016-10-06 07:25:00,2016-10-06 10:50:00,2016-10-06 07:25:21,2016-10-06 07:25:21
+87,96,0,NZL,en,general notifications,severe thunderstorm,[auckland cdem] a significant thunderstorm activity and rain and wind is starting to occur in this subnational.  if you have significant thunderstorms where you are please stay inside and away from windows.  auckland civil defence is monitoring this event.  ,"{""type"":""Polygon"",""coordinates"":[[[174.31182861328,-36.732280756072],[174.91058349609,-36.660707868219],[174.94079589844,-36.517362315727],[174.93118286133,-36.371539245849],[174.6826171875,-36.41023115104],[174.19647216797,-36.414651856777],[174.09210205078,-36.482036438804],[174.31182861328,-36.732280756072]]]}",auckland north,alert,actual,public,geo,immediate,extreme,observed,2016-10-06 07:27:31,2016-10-06 07:25:00,2016-10-06 07:25:00,2016-10-06 10:50:00,2016-10-06 07:25:21,2016-10-06 07:25:21
 88,96,0,NZL,en,rain warning,heavy rain warning for south westland,"[cdwc] heavy rain is expected to develop early tuesday morning. in the 21 hours from 6am tuesday to 3am wednesday, 140 to 180mm is forecast to accumulate, especially about the ranges. peak intensities 20 to 30mm per hour.","{""type"":""Polygon"",""coordinates"":[[[169.72229003906,-43.387744637161],[170.3796293959,-43.45690646829],[169.26545100287,-44.21502882031],[168.64837646484,-44.002041506003],[169.72229003906,-43.387744637161]]]}",south westland,alert,actual,public,met,immediate,severe,likely,2016-10-09 20:44:24,2016-10-10 11:00:00,2016-10-09 20:10:00,2016-10-11 20:00:00,2016-10-09 20:42:12,2016-10-09 20:42:12
 89,96,0,NZL,en,general notifications,this is the wremo polygon test. 11 point data,[wremo] ****polygon test****,"{""type"":""Polygon"",""coordinates"":[[[66.037750244141,-50.506439832105],[66.359100341797,-50.455755375675],[66.345367431641,-50.586724406246],[66.268463134766,-50.652943367257],[66.284942626953,-50.833697670981],[66.142120361328,-50.968805734318],[65.941619873047,-50.948045393551],[65.793304443359,-50.830228205617],[65.868835449219,-50.693847915896],[65.885314941406,-50.608517250114],[66.037750244141,-50.506439832105]]]}",auckland island,alert,test,public,geo,immediate,minor,observed,2016-10-13 21:08:30,2016-10-13 21:08:00,2016-10-13 21:08:00,2016-10-13 22:00:00,2016-10-13 21:06:15,2016-10-13 21:06:15
 90,96,0,NZL,en,general notifications,"polygon test, no ",[wremo] ***test*** ,"{""type"":""Polygon"",""coordinates"":[[[165.73425292969,-50.394512080234],[166.80541992188,-50.299867016749],[166.52526855469,-51.272225924456],[165.15747070312,-51.292841127327],[165.73425292969,-50.394512080234]]]}",auckland island,alert,test,public,geo,immediate,minor,observed,2016-10-13 22:04:12,2016-10-13 22:05:00,2016-10-13 22:05:00,2016-10-14 01:00:00,2016-10-13 22:01:53,2016-10-13 22:01:53
@@ -159,76 +159,76 @@ issued at 5:00 pm, 18 october 2016
 
 as of 4pm, ty lawin is at 930 km east of tayabas, quezon with max winds up to 185 kph and gustiness of  230 kph. forecast to move wnw at 25 kph.
 
-rainfall amount will be moderate to heavy within the 650 km 
+rainfall amount will be moderate to heavy within the 650 km
 
 diameter of the typhoon.
 
-it is expected to intensify before making landfall over 
+it is expected to intensify before making landfall over
 
-cagayan area by thursday early morning (oct. 20) then cross ilocos norte and apayao and exit par by fri morning (oct. 
+cagayan area by thursday early morning (oct. 20) then cross ilocos norte and apayao and exit par by fri morning (oct.
 
 21).
 
-forecast positions: 
-24hrs (tom afternoon): 330 km east of casiguran, aurora 
+forecast positions:
+24hrs (tom afternoon): 330 km east of casiguran, aurora
 48hrs (thu afternoon): 95 km northwest of laoag city, ilocos norte
-72hrs (fri afternoon): 565 km northwest of laoag city, ilocos norte (outside par) 
+72hrs (fri afternoon): 565 km northwest of laoag city, ilocos norte (outside par)
 
 warning signal
-#1:ilocos norte, apayao, cagayan including calayan group of islands, batanes group of islands, isabela, kalinga, abra, ilocos sur, mt. province, ifugao, quirino, nueva vizcaya, benguet, la union, aurora, nueva ecija, pangasinan, catanduanes and polillo islands 
+#1:ilocos norte, apayao, cagayan including calayan group of islands, batanes group of islands, isabela, kalinga, abra, ilocos sur, mt. province, ifugao, quirino, nueva vizcaya, benguet, la union, aurora, nueva ecija, pangasinan, catanduanes and polillo islands
 
-please report any untoward incident to prc opcen at 
+please report any untoward incident to prc opcen at
 
 09188076734, hotline 143 or (02) 790 2300
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[120.4541015625,19.518375478602],[118.6962890625,15.284185114076],[119.5751953125,13.239945499286],[118.212890625,10.833305983642],[115.927734375,8.537565350804],[118.0810546875,7.4931964701223],[120.8935546875,10.660607953625],[121.5087890625,9.3189901923979],[121.4208984375,7.928674801364],[120.9814453125,6.7082539686715],[121.7724609375,6.1405547824503],[123.134765625,6.4899833326707],[123.486328125,6.8828002417676],[123.5302734375,5.9657536710655],[125.068359375,5.0471707369197],[126.7822265625,5.6597185545773],[127.2216796875,7.0136679275666],[127.2216796875,8.2332371112746],[126.123046875,12.897489183756],[123.310546875,14.774882506516],[122.5634765625,15.792253570362],[123.662109375,17.644022027873],[122.080078125,18.979025953255],[120.4541015625,19.518375478602]]]}",northern and central luzon,alert,actual,public,geo,immediate,extreme,observed,2016-10-18 09:30:50,2016-10-18 16:00:00,2016-10-18 09:00:00,2016-10-20 15:00:00,2016-10-18 09:28:42,2016-10-18 09:28:42
 93,165,0,PHL,en,general notifications,"typhoon lawin (haima) update #13 issued at 11:00 pm, 19 october 2016","[philippines red cross] typhoon lawin (haima) update #13 issued at 11:00 pm, 19 october 2016
 
-as of 10pm, ty lawin is at 95 km east of tuguegarao city, cagayan with max winds up to 225 kph near the center 
+as of 10pm, ty lawin is at 95 km east of tuguegarao city, cagayan with max winds up to 225 kph near the center
 and gustiness of up to 315 kph
 
 rainfall amount will be moderate to heavy within the 800 km diameter of the typhoon.
 
 make landfall at made landfall over baguio pt., peñablanca, cagayan to early morning (2:00 am, oct. 20) then will cross apayao and ilocos norte and to exit par this evening (oct. 20).
 
-forecast positions: 
+forecast positions:
 24hrs (tom evening): 330 km west northwest of laoag city, ilocos norte
 48hrs (fri evening): 805 km west northwest of basco, batanes
 72hrs (sat evening): 995 km northwest of basco, batanes (outside par)
 
 warning signal
-#5: cagayan, isabela, kalinga, apayao, northern abra and ilocos norte  
+#5: cagayan, isabela, kalinga, apayao, northern abra and ilocos norte
 
 #4: rest of abra, ilocos sur, mt. province, ifugao and calayan group of islands
 
-#3: la union, benguet, nueva vizcaya, quirino and northern aurora 
+#3: la union, benguet, nueva vizcaya, quirino and northern aurora
 
-#2: batanes group of islands, pangasinan, rest of of aurora, tarlac, nueva ecija, northern zambales,  and northern quezon including polillo islands 
+#2: batanes group of islands, pangasinan, rest of of aurora, tarlac, nueva ecija, northern zambales,  and northern quezon including polillo islands
 
 #1: rest of zambales, bulacan, bataan, pampanga, rizal, rest of quezon, cavite, laguna, batangas, camarines norte, camarines sur, catanduanes, albay and metro manila
 
-please report any untorward incident to prc opcen at 
+please report any untorward incident to prc opcen at
 
 09188076734, hotline 143 or (02) 790 2300
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[20.849609375,19.890723023997],[19.53125,16.720385051694],[20.1025390625,13.453737213419],[19.53125,11.953349393643],[18.1689453125,10.703791711681],[16.982421875,9.1454860561673],[16.3671875,7.5367643220841],[18.564453125,7.7980785313553],[20.6298828125,10.228437266156],[21.11328125,11.264612212504],[21.376953125,10.228437266156],[21.46484375,8.1027385777832],[19.9267578125,5.6597185545773],[19.53125,4.828259746867],[23.0029296875,6.4026484059639],[24.0576171875,4.8720477002419],[26.826171875,5.2222465132274],[27.177734375,7.62388685312],[26.6943359375,11.049038346537],[25.2880859375,14.817370620155],[22.7392578125,15.665354182093],[22.783203125,17.936928637549],[22.080078125,19.890723023997],[20.849609375,19.890723023997]]]}",northern and central luzon,alert,actual,public,geo,immediate,extreme,observed,2016-10-19 16:49:47,2016-10-20 16:00:00,2016-10-19 15:00:00,2016-10-19 21:00:00,2016-10-19 16:47:33,2016-10-19 16:47:33
 94,165,0,PHL,en,general notifications,"typhoon lawin (haima) update #14 issued at 5:00 am, 20 october 2016","[philippines red cross] typhoon lawin (haima) update #14 issued at 5:00 am, 20 october 2016
 
-as of 4am, ty lawin is at vicinity of cabugao, apayao with max winds up to 205 kph near the center 
+as of 4am, ty lawin is at vicinity of cabugao, apayao with max winds up to 205 kph near the center
 and gustiness of up to 285 kph
 
 rainfall amount will be heavy to intense within the 400 km inner diameter of the 800 km diameter of the typhoon
 
 make landfall at made landfall over baguio pt., peñablanca, to exit the landmass via ilocos norte between 8-10 this morning and possible to exit par this evening (october 20).
 
-forecast positions: 
+forecast positions:
 24hrs (tom morning): 95 km west northwest of laoag city, ilocos norte (outside par)
 72hrs (sat evening): 885 km west northwest of basco, batanes (outside
 
 warning signal
 #4: cagayan, isabela, apayao, abra, ilocos norte, ilocos sur, mt. province, kalinga, ifugao and calayan group of islands
 
-#3: la union, benguet, nueva vizcaya, quirino and northern aurora 
+#3: la union, benguet, nueva vizcaya, quirino and northern aurora
 
 #2: batanes group of islands, pangasinan, rest of of aurora, tarlac, nueva ecija and northern zambales
 
@@ -240,7 +240,7 @@ high tide, today: 2:27 pm - (0.45m)
 low tide, today: 4:48 pm - (0.41m)
 high tide, today: 12:37 am - (1.11m)
 
-please report any untorward incident to prc opcen at 
+please report any untorward incident to prc opcen at
 
 09188076734, hotline 143 or (02) 790 2300
 
@@ -253,7 +253,7 @@ as of 10pm, ty lawin is at 390 km west northwest of laoag city, ilocos norte wit
 
  all tropical cyclone warning signal (tcws) are now lifted.
 
-forecast positions: 
+forecast positions:
 24 hr (tom evening): 815 km west northwest of basco, batanes (outside par)
 48 hr (sat evening): 965 km north northwest of basco, batanes (outside par)
 72 hr (sun evening): 1,200 km north northeast of basco, batanes (outside par)
@@ -277,7 +277,7 @@ strength: max. sustained winds of 55 kph near the center and gustiness of up to 
 
 forecast movement: to move northwest at 19 kph
 
-forecast positions: 
+forecast positions:
 - 24 hr ( tomorrow afternoon): 105 km west of roxas city, capiz
 - 48 hr (saturday afternoon):295 km west of calapan city, oriental mindoro
 - 72 hr  (sunday afternoon): 395 km west northwest of iba, zambales
@@ -301,13 +301,13 @@ expected to exit the par by sunday evening (november 27) or monday early morning
 
 location of eye/center: at 10 pm today, the center of td marce was est. over the coast of baybay, leyte
 
-strength: max. sustained winds of 55 kph near the center and gustiness of up to 95 
+strength: max. sustained winds of 55 kph near the center and gustiness of up to 95
 
 kph
 
 forecast movement: to move northwest at 19 kph
 
-forecast positions: 
+forecast positions:
 - 24 hr ( tomorrow evening): 50 km north northeast of coron, palawan.
 - 48 hr (saturday evening): 255 km west of iba, zambales(15.2°n, 117.6°e)
 - 72 hr (sunday evening): 575 km west of sinait, ilocos sur (outside par)
@@ -332,7 +332,7 @@ operations center","{""type"":""Polygon"",""coordinates"":[[[120.234375,19.76670
 
 marce has intensified into a tropical storm as it moves towards panay island.
 
-expected to exit the par by sunday evening (november 27). 
+expected to exit the par by sunday evening (november 27).
 
 location of eye/center: at 4am today, the center of typhoon was estimated at 85 km east southeast of roxas city, capiz
 
@@ -340,7 +340,7 @@ strength: max. sustained winds of 65 kph near the center and gustiness of up to 
 
 forecast movement: to move northwest at 24 kph
 
-forecast positions: 
+forecast positions:
 - 24 hr ( tomorrow morning): 160 km north northwest of coron, palawan
 - 48 hr (saturday morning): 325 km west of iba, zambales
 - 72 hr (sunday morning): 680 km west of sinait, ilocos sur (outside par)
@@ -356,14 +356,14 @@ northern palawan including cuyo island, rest of oriental mindoro, rest of occide
 
 wave height: (open sea) 1.25-4.0 meters
 
-please report any untoward incident to prc opcen at hotline 143; globe-09561481234; smart-09188076734; landline- 
+please report any untoward incident to prc opcen at hotline 143; globe-09561481234; smart-09188076734; landline-
 
 (02) 790 2300
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[120.41015625,18.979025953255],[119.4873046875,16.804541076383],[119.794921875,13.410994034322],[119.2236328125,12.16822567739],[118.1689453125,10.401377554544],[116.4990234375,8.1027385777832],[116.71875,7.4060477170763],[118.212890625,7.8851472834243],[120.8935546875,11.523087506869],[121.904296875,9.1454860561673],[121.552734375,6.9264268470596],[120.1904296875,6.2279339302687],[120.673828125,5.0471707369197],[123.486328125,6.7955350257195],[124.8486328125,5.0909441750334],[126.7822265625,5.7471740766514],[127.2216796875,7.9721977143869],[125.9033203125,12.511665400971],[124.2333984375,14.647368383897],[122.958984375,14.902321826142],[122.6953125,15.834535741222],[123.310546875,17.560246503295],[122.2119140625,19.020577110967],[120.41015625,18.979025953255]]]}",luzon and visayas ,alert,actual,public,geo,immediate,severe,observed,2016-11-24 21:48:27,2016-11-24 21:00:00,2016-11-24 21:00:00,2016-11-25 02:00:00,2016-11-24 21:45:09,2016-11-24 21:45:09
 104,165,0,PHL,en,general notifications,"ts marce severe weather bulletin as of 8pm, november 25, 2016","[philippines red cross] ts marce severe weather bulletin as of 8pm, november 25, 2016
 
-location of eye/center: at 7pm today, the center of tropical storm was estimated in the vicinity of coron town proper, 
+location of eye/center: at 7pm today, the center of tropical storm was estimated in the vicinity of coron town proper,
 palawan
 
 strength: max. sustained winds of 65 kph near the center and gustiness of up to 100 kph
@@ -372,25 +372,25 @@ movement: to move northwest at 17 kph
 
 expected to exit par by sunday late morning or afternoon (nov. 27).
 
-tropical cyclone warning signals elsewhere are now lifted. 
+tropical cyclone warning signals elsewhere are now lifted.
 
-forecast positions: 
+forecast positions:
 - 24 hr ( tomorrow afternoon): 255 km west southwest of iba, zambales
 - 48 hr (sunday afternoon): 520 km west of sinait, ilocos sur (outside par)
 - 72 hr (monday afternoon): 560 km north northwest of pagasa island, palawan (outside par)
 
-tropical cyclone warning signal, elsewhere are now lifted. 
+tropical cyclone warning signal, elsewhere are now lifted.
 
-#2: calamian group of islands 
+#2: calamian group of islands
 wave height: (open sea) 4.1-14.0 meters storm surge possible at coastal areas
 
 #1: occidental mindoro and northern palawan including cuyo island
 wave height: (open sea) 1.25-4.0 meters
 
-residents of areas under tcws #2 and #1 and the rest of bicol region and the provinces of aurora and quezon are 
+residents of areas under tcws #2 and #1 and the rest of bicol subnational and the provinces of aurora and quezon are
 alerted against possible flashfloods and landslides.
 
-please report any untoward incident to prc opcen at hotline 143; globe-09561481234; smart-09188076734; landline- 
+please report any untoward incident to prc opcen at hotline 143; globe-09561481234; smart-09188076734; landline-
 
 (02) 790 2300
 
@@ -407,22 +407,22 @@ movement: to move northwest at 17 kph
 
 expected to exit par by sunday late morning or afternoon (nov. 27)
 
-tropical cyclone warning signals elsewhere are now lifted. 
+tropical cyclone warning signals elsewhere are now lifted.
 
-forecast positions: 
+forecast positions:
 - 24 hr ( tomorrow evening): 280 km west of iba, zambales
 - 48 hr (sunday evening) 540 km west of sinait, ilocos sur (outside par)
 - 72 hr (monday evening) 560 km north northwest of pagasa island, palawan (outside par)
 
-tropical cyclone warning signal, elsewhere are now lifted. 
+tropical cyclone warning signal, elsewhere are now lifted.
 
-#2: calamian group of islands 
+#2: calamian group of islands
 wave height: (open sea) 4.1-14.0 meters storm surge possible at coastal areas
 
 #1: occidental mindoro and northern palawan
 wave height: (open sea) 1.25-4.0 meters
 
-please report any untoward incident to prc opcen at hotline 143; globe-09561481234; smart-09188076734; landline- 
+please report any untoward incident to prc opcen at hotline 143; globe-09561481234; smart-09188076734; landline-
 
 (02) 790 2300
 
@@ -439,26 +439,26 @@ movement: to move northwest at 15 kph
 
 expected to exit par by saturday morning (nov. 26) or sunday afternoon (nov. 27)
 
-tropical cyclone warning signals elsewhere are now lifted. 
+tropical cyclone warning signals elsewhere are now lifted.
 
-forecast positions: 
+forecast positions:
 - 24 hr (tonight): 325 km west of iba, zambales
 - 48 hr (monday evening): 605 km west of sinait, ilocos sur (outside par)
 - 72 hr (tuesday, morning) 540 km north northwest of pagasa island, palawan (outside par)
 
-tropical cyclone warning signal, elsewhere are now lifted. 
+tropical cyclone warning signal, elsewhere are now lifted.
 
 #1: calamian group of islands
 wave height: (open sea) 1.25-4.0 meters
 
-cloudy skies with moderate to occasionally heavy rains and thunderstorms which may trigger flashfloods and landslides will be experienced over mimaropa, bicol region and the provinces of quezon and aurora.
+cloudy skies with moderate to occasionally heavy rains and thunderstorms which may trigger flashfloods and landslides will be experienced over mimaropa, bicol subnational and the provinces of quezon and aurora.
 
 mdd, rrr","{""type"":""Polygon"",""coordinates"":[[[120.4541015625,19.145168196205],[118.30078125,12.254127737657],[116.3671875,7.5803277913301],[117.9931640625,7.5367643220841],[121.2890625,11.523087506869],[120.8056640625,7.188100871179],[119.3994140625,4.959615024698],[123.662109375,5.9657536710655],[125.4638671875,4.5216663426148],[127.6171875,6.8828002417676],[125.6396484375,14.689881366619],[123.0908203125,17.685895196739],[122.080078125,19.683970235888],[120.4541015625,19.145168196205]]]}","calamian group of islands, palawan",alert,actual,public,geo,immediate,moderate,observed,2016-11-25 21:45:04,2016-11-25 21:00:00,2016-11-25 21:00:00,2016-11-26 02:00:00,2016-11-25 21:41:46,2016-11-25 21:41:46
 107,96,0,NZL,en,tsunami advisory,potential coastal and marine tsunami threat,[waikato cdem] stay out of the water and away from beaches. we will send another alert when we know more.,"{""type"":""Polygon"",""coordinates"":[[[173.79272460938,-37.544577320856],[175.33081054688,-36.004673486702],[177.46215820312,-37.265309955619],[174.32006835938,-38.745515184883],[173.79272460938,-37.544577320856]]]}",waikato coastal areas,alert,actual,public,geo,expected,moderate,possible,2016-12-08 18:59:37,2016-12-08 11:00:00,2016-12-08 11:00:00,2016-12-09 11:00:00,2016-12-08 18:56:24,2016-12-08 18:56:24
 108,96,0,NZL,en,tsunami watch,calm your farm coromandel,"[waikato cdem] the potential tsunami threat is a marine and coastal alert at this stage, so no need to self evacuate around the coromandel at the moment. we will have time before the expected lunchtime arrival to know what the situation will be. so, calm the farm at the moment coromandel.","{""type"":""Polygon"",""coordinates"":[[[175.69061279297,-36.352739087359],[175.14953613281,-36.476515314829],[175.45440673828,-37.276238364943],[176.06414794922,-37.415981841946],[176.12182617188,-36.637570081239],[175.69061279297,-36.352739087359]]]}",coromandel,alert,actual,public,geo,immediate,moderate,possible,2016-12-08 19:10:30,2016-12-09 11:00:00,2016-12-08 11:00:00,2016-12-10 11:00:00,2016-12-08 19:07:30,2016-12-08 19:07:30
 109,96,0,NZL,en,general notifications,auckland - no evacuation required. marine/coastal threat only. ,"[auckland cdem] we are monitoring the effect of a 7.7 magnitude earthquake which struck south east of the solomon islands this morning.
-currently no evacuation is required for the auckland region.
-a marine and beach threat has been issued, and the ministry of civil defence and emergency management has advised: 
+currently no evacuation is required for the auckland subnational.
+a marine and beach threat has been issued, and the ministry of civil defence and emergency management has advised:
 1. stay out of the water (sea, rivers and estuaries, including boating activities)
 2. stay off beaches and shore areas
 3. do not go sightseeing
@@ -466,7 +466,7 @@ a marine and beach threat has been issued, and the ministry of civil defence and
 5. listen to the radio and/or tv for updates
 ","{""type"":""Polygon"",""coordinates"":[[[173.57849121094,-36.469889446816],[175.15502929688,-35.853439619592],[176.17126464844,-36.346102653006],[175.13854980469,-36.447799129585],[175.39672851562,-37.116526184911],[174.35302734375,-37.461778479617],[173.57849121094,-36.469889446816]]]}",auckland,alert,actual,public,geo,immediate,moderate,observed,2016-12-08 19:24:17,2016-12-09 11:00:00,2016-12-08 11:00:00,2016-12-10 11:00:00,2016-12-08 19:21:24,2016-12-08 19:21:24
 110,96,0,NZL,en,general notifications,threat cancelled but still weird water situation,"[waikato cdem] the potential marine tsunami threat has been cancelled but we are advising people there could be strong and unusual currents so please staybout of the water. based on our modelling, the effects may begin around low tide at lunch time and continue through past the next high tide.","{""type"":""Polygon"",""coordinates"":[[[176.5283203125,-37.112145754751],[176.20422363281,-37.422525934563],[174.44091796875,-38.852542390364],[174.57824707031,-37.848832506474],[174.462890625,-37.278423856454],[175.41320800781,-36.980615065286],[175.341796875,-36.765291917116],[175.23193359375,-36.544949441483],[175.23742675781,-36.00022956178],[175.77026367188,-35.964669147704],[176.5283203125,-37.112145754751]]]}",waikato,update,actual,public,geo,future,minor,unlikely,2016-12-08 19:39:55,2016-12-09 11:00:00,2016-12-08 19:00:00,2016-12-10 11:00:00,2016-12-08 19:36:31,2016-12-08 19:36:31
-111,96,0,NZL,en,general notifications,auckland - tsunami threat cancelled - solomon islands earthquake.,"[auckland cdem] tsunami threat cancelled - solomon islands earthquake 
+111,96,0,NZL,en,general notifications,auckland - tsunami threat cancelled - solomon islands earthquake.,"[auckland cdem] tsunami threat cancelled - solomon islands earthquake
 
 the ministry of civil defence and emergency management has advised that the potential tsunami threat for new zealand has been cancelled.
 
@@ -496,7 +496,7 @@ strength: max sustained winds of 115kph near the center and gustiness of up to 1
 
 movement: west northwest at 19kph
 
-forecast positions: 
+forecast positions:
 24 hour( tomorrow evening): 285 km northeast of borongan city, eastern samar
 48 hour(sunday evening):20 km east of virac, catanduanes
 72 hour(monday evening): 95 km southwest of subic, olongapo
@@ -533,7 +533,7 @@ forecast positions:
 
 tropical cyclone warning signal:
 
-signal no. 2 
+signal no. 2
 luzon: camarines sur, masbate including ticao and burias island, catanduanes, albay and sorsogon
 
 visayas: northern samar.
@@ -543,11 +543,11 @@ luzon: metro manila, bulacan, cavite, laguna, batangas, rizal, quezon including 
 
 visayas: aklan, capiz, samar, eastern samar, biliran, leyte and bantayan island
 
-kindly monitor and report any untoward incident to prc opcen at 09188076734; 
+kindly monitor and report any untoward incident to prc opcen at 09188076734;
 
 landline- (02) 790 2300
 
-operations center","{""type"":""Polygon"",""coordinates"":[[[120.322265625,19.228176737766],[119.3115234375,16.383391123608],[119.4873046875,12.897489183756],[116.3232421875,8.1462428250344],[116.6748046875,7.3624668655358],[121.5966796875,10.833305983642],[120.8935546875,5.6597185545773],[123.75,4.828259746867],[129.19921875,4.959615024698],[126.826171875,10.401377554544],[124.27734375,16.551961721973],[122.255859375,19.518375478602],[120.322265625,19.228176737766]]]}","luzon, bicol region and visayas",alert,actual,public,geo,immediate,severe,observed,2016-12-24 13:19:02,2016-12-24 14:00:00,2016-12-24 12:08:00,2016-12-24 14:00:00,2016-12-24 13:15:19,2016-12-24 13:15:19
+operations center","{""type"":""Polygon"",""coordinates"":[[[120.322265625,19.228176737766],[119.3115234375,16.383391123608],[119.4873046875,12.897489183756],[116.3232421875,8.1462428250344],[116.6748046875,7.3624668655358],[121.5966796875,10.833305983642],[120.8935546875,5.6597185545773],[123.75,4.828259746867],[129.19921875,4.959615024698],[126.826171875,10.401377554544],[124.27734375,16.551961721973],[122.255859375,19.518375478602],[120.322265625,19.228176737766]]]}","luzon, bicol subnational and visayas",alert,actual,public,geo,immediate,severe,observed,2016-12-24 13:19:02,2016-12-24 14:00:00,2016-12-24 12:08:00,2016-12-24 14:00:00,2016-12-24 13:15:19,2016-12-24 13:15:19
 115,165,0,PHL,en,general notifications,"typhoon nina update  #9 as of 11:00 pm, 24 december 2016","[philippines red cross] nina  has maintained its strength as it continues to move towards bicol area.
 
 estimated rainfall amount is from moderate to heavy within its 500 km diameter of the typhoon.
@@ -574,23 +574,23 @@ tropical cyclone warning signal:
 signal no. 3
 luzon: catanduanes
 
-signal no. 2 
-luzon: camarines norte, camarines sur, masbate including ticao and burias island, albay and sorsogon 
+signal no. 2
+luzon: camarines norte, camarines sur, masbate including ticao and burias island, albay and sorsogon
 
 visayas: northern samar.
 
 signal no. 1
-luzon: metro manila, bataan, southern zambales, pampanga, nueva ecija, bulacan, cavite, laguna, batangas, rizal, quezon including polillo island, aurora, romblon, marinduque, occidental mindoro including lubang island and oriental mindoro 
+luzon: metro manila, bataan, southern zambales, pampanga, nueva ecija, bulacan, cavite, laguna, batangas, rizal, quezon including polillo island, aurora, romblon, marinduque, occidental mindoro including lubang island and oriental mindoro
 
 visayas: aklan, capiz, samar, eastern samar, biliran, leyte and bantayan island.
 
-kindly monitor and report any untoward incident to prc opcen at 09188076734; 
+kindly monitor and report any untoward incident to prc opcen at 09188076734;
 
 landline- (02) 790 2300
 
-operations center","{""type"":""Polygon"",""coordinates"":[[[120.6298828125,19.228176737766],[119.443359375,16.341225619207],[120.0146484375,12.768946439456],[116.5869140625,8.276727101164],[116.2353515625,7.3188817303668],[121.201171875,9.7523701391733],[120.1904296875,6.5773031181239],[119.3994140625,4.6968790268714],[123.7939453125,6.0531612957141],[127.0458984375,3.7765593098769],[127.6611328125,10.271681232947],[125.2001953125,18.396230138029],[121.7724609375,19.766703551717],[120.6298828125,19.228176737766]]]}","luzon,  bicol region and visayas",alert,actual,public,geo,immediate,severe,observed,2016-12-24 16:03:11,2016-12-24 20:00:00,2016-12-24 15:00:00,2016-12-24 20:00:00,2016-12-24 15:59:26,2016-12-24 15:59:26
+operations center","{""type"":""Polygon"",""coordinates"":[[[120.6298828125,19.228176737766],[119.443359375,16.341225619207],[120.0146484375,12.768946439456],[116.5869140625,8.276727101164],[116.2353515625,7.3188817303668],[121.201171875,9.7523701391733],[120.1904296875,6.5773031181239],[119.3994140625,4.6968790268714],[123.7939453125,6.0531612957141],[127.0458984375,3.7765593098769],[127.6611328125,10.271681232947],[125.2001953125,18.396230138029],[121.7724609375,19.766703551717],[120.6298828125,19.228176737766]]]}","luzon,  bicol subnational and visayas",alert,actual,public,geo,immediate,severe,observed,2016-12-24 16:03:11,2016-12-24 20:00:00,2016-12-24 15:00:00,2016-12-24 20:00:00,2016-12-24 15:59:26,2016-12-24 15:59:26
 116,165,0,PHL,en,general notifications,"
-typhoon nina update #11 as of 5:00 am, 25 december 2016","[philippines red cross] nina  has maintained its strength as it continues to endager bicol region.
+typhoon nina update #11 as of 5:00 am, 25 december 2016","[philippines red cross] nina  has maintained its strength as it continues to endager bicol subnational.
 
 estimated rainfall amount is from moderate to heavy within its 500 km diameter of the typhoon.
 
@@ -615,7 +615,7 @@ tropical cyclone warning signal:
 signal no. 3
 luzon: catanduanes, albay and camarines sur
 
-signal no. 2 
+signal no. 2
 luzon: southern quezon, marinduque, camarines norte, masbate including ticao and burias island, and sorsogon
 
 visayas: northern samar.
@@ -625,11 +625,11 @@ luzon: metro manila, bataan, nueva ecija, southern nueva vizcaya, southern quiri
 
 visayas: aklan, capiz, samar, eastern samar, biliran, leyte and bantayan island
 
-kindly monitor and report any untoward incident to prc opcen at 09188076734; 
+kindly monitor and report any untoward incident to prc opcen at 09188076734;
 
 landline- (02) 790 2300
 
-operations center","{""type"":""Polygon"",""coordinates"":[[[120.322265625,19.725342248058],[119.0478515625,14.604847155054],[117.2021484375,9.2322487994187],[116.4111328125,7.1444988496473],[121.5087890625,10.055402736564],[120.322265625,5.9657536710655],[119.9267578125,4.6530799182741],[125.6396484375,5.5285105256928],[128.4521484375,5.8783321096743],[126.6943359375,14.987239525774],[123.5302734375,20.220965779522],[120.322265625,19.725342248058]]]}","luzon, bicol and visayas region",alert,actual,public,geo,immediate,severe,observed,2016-12-24 21:46:49,2016-12-24 23:00:00,2016-12-24 21:00:00,2016-12-24 23:00:00,2016-12-24 21:43:03,2016-12-24 21:43:03
+operations center","{""type"":""Polygon"",""coordinates"":[[[120.322265625,19.725342248058],[119.0478515625,14.604847155054],[117.2021484375,9.2322487994187],[116.4111328125,7.1444988496473],[121.5087890625,10.055402736564],[120.322265625,5.9657536710655],[119.9267578125,4.6530799182741],[125.6396484375,5.5285105256928],[128.4521484375,5.8783321096743],[126.6943359375,14.987239525774],[123.5302734375,20.220965779522],[120.322265625,19.725342248058]]]}","luzon, bicol and visayas subnational",alert,actual,public,geo,immediate,severe,observed,2016-12-24 21:46:49,2016-12-24 23:00:00,2016-12-24 21:00:00,2016-12-24 23:00:00,2016-12-24 21:43:03,2016-12-24 21:43:03
 117,165,0,PHL,en,general notifications,"typhoon nina (nock-ten) update #17 as of 11:00 pm, 25 december 2016","[philippines red cross] ""nina"" has made its 2nd landfall over sagnay, camarines sur
 
 estimated rainfall amount is from moderate to heavy within the 400 km diameter of the typhoon.
@@ -641,7 +641,7 @@ location: at 10:00 pm today, the eye of typhoon ""nina"" was at at the border of
 strength: max sustained winds of up to 175 kph near the center and gustiness of up to 290 kph.
 
 forecast to move west at 20 kph.
- 
+
 forecast positions:
 24 hour( tomorrow evening): 150 km west southwest of sangley pt, cavite
 48 hour(tuesday evening): 480 km west of subic, olongapo
@@ -662,10 +662,10 @@ pangasinan, nueva ecija, aurora, quirino, nueva vizcaya, zambales, pampanga, tar
 
 visayas: northern samar
 
-please report any untoward incident to prc opcen at hotline 143; 
+please report any untoward incident to prc opcen at hotline 143;
 globe-09561481234; smart-09188076734; landline- (02) 790 2300
 
-operations center","{""type"":""Polygon"",""coordinates"":[[[120.05859375,19.062117883515],[118.828125,15.156973713378],[118.6962890625,12.125264218332],[116.7626953125,8.7113588754265],[116.19140625,7.2752923363722],[120.41015625,8.971897294083],[120.9375,7.0572823529716],[119.7509765625,5.1784820885229],[122.5634765625,4.7844689665794],[126.9140625,4.828259746867],[128.3203125,8.1027385777832],[127.2216796875,15.156973713378],[124.1015625,18.937464429642],[121.640625,20.509354588715],[120.05859375,19.062117883515]]]}","ncr, southern luzon, bicol region and visayas",alert,actual,public,geo,immediate,severe,observed,2016-12-25 15:46:08,2016-12-25 17:00:00,2016-12-25 15:00:00,2016-12-25 17:00:00,2016-12-25 15:42:23,2016-12-25 15:42:23
+operations center","{""type"":""Polygon"",""coordinates"":[[[120.05859375,19.062117883515],[118.828125,15.156973713378],[118.6962890625,12.125264218332],[116.7626953125,8.7113588754265],[116.19140625,7.2752923363722],[120.41015625,8.971897294083],[120.9375,7.0572823529716],[119.7509765625,5.1784820885229],[122.5634765625,4.7844689665794],[126.9140625,4.828259746867],[128.3203125,8.1027385777832],[127.2216796875,15.156973713378],[124.1015625,18.937464429642],[121.640625,20.509354588715],[120.05859375,19.062117883515]]]}","ncr, southern luzon, bicol subnational and visayas",alert,actual,public,geo,immediate,severe,observed,2016-12-25 15:46:08,2016-12-25 17:00:00,2016-12-25 15:00:00,2016-12-25 17:00:00,2016-12-25 15:42:23,2016-12-25 15:42:23
 118,165,0,PHL,en,general notifications,"typhoon nina (nock-ten) update #18 as of 2:00 am, 26 december 2016","[philippines red cross] ""nina"" is now traversing ragay gulf.
 
 estimated rainfall amount is from moderate to heavy within the 400 km diameter of the typhoon.
@@ -677,7 +677,7 @@ location: at 1:00 am today, the eye of typhoon ""nina"" was at 55 km west southw
 strength: max sustained winds of up to 175 kph near the center and gustiness of up to 290 kph.
 
 forecast to move west at 20 kph.
- 
+
 forecast positions:
 24 hour( tonight): 165 km west southwest of subic, olongapo
 48 hour(wednesday morning):520 km west of subic, olongapo
@@ -692,10 +692,10 @@ signal #2: metro manila, rizal, bulacan, bataan, pampanga, southern zambales, po
 
 signal #1 the rest of occidental mindoro, romblon, masbate including ticao island, northern zambales, tarlac, nueva ecija, southern aurora, and pangasinan
 
-please report any untoward incident to prc opcen at hotline 143; 
+please report any untoward incident to prc opcen at hotline 143;
 globe-09561481234; smart-09188076734; landline- (02) 790 2300
 
-operations center","{""type"":""Polygon"",""coordinates"":[[[120.3662109375,19.103648251664],[119.4873046875,15.411319377981],[118.7841796875,11.264612212504],[116.1474609375,8.1462428250344],[117.3779296875,7.2316987083671],[121.46484375,10.358151400944],[120.0146484375,5.6597185545773],[129.90234375,4.3464112753332],[128.3642578125,8.1897423443837],[124.8046875,21.657428197371],[120.3662109375,19.103648251664]]]}","ncr, southern luzon and bicol region",alert,actual,public,geo,immediate,severe,observed,2016-12-25 18:58:31,2016-12-25 20:00:00,2016-12-25 18:00:00,2016-12-25 20:00:00,2016-12-25 18:54:46,2016-12-25 18:54:46
+operations center","{""type"":""Polygon"",""coordinates"":[[[120.3662109375,19.103648251664],[119.4873046875,15.411319377981],[118.7841796875,11.264612212504],[116.1474609375,8.1462428250344],[117.3779296875,7.2316987083671],[121.46484375,10.358151400944],[120.0146484375,5.6597185545773],[129.90234375,4.3464112753332],[128.3642578125,8.1897423443837],[124.8046875,21.657428197371],[120.3662109375,19.103648251664]]]}","ncr, southern luzon and bicol subnational",alert,actual,public,geo,immediate,severe,observed,2016-12-25 18:58:31,2016-12-25 20:00:00,2016-12-25 18:00:00,2016-12-25 20:00:00,2016-12-25 18:54:46,2016-12-25 18:54:46
 119,165,0,PHL,en,general notifications,"typhoon nina (nock-ten) update #19 as of 5:00 am, 26 december 2016","[philippines red cross] ""nina"" has slightly weakened and is now traversing mompog pass
 
 estimated rainfall amount is from moderate to heavy within the 400 km diameter of the typhoon.
@@ -707,9 +707,9 @@ location: at 4:00 am today, the eye of typhoon was located at 85 km north of rom
 strength: max sustained winds of up to 150 kph near the center and gustiness of up to 250 kph.
 
 forecast to move west at 20 kph.
- 
+
 forecast positions:
-24 hour( tomorrow morning): 200 km west southwest of iba, zambales 
+24 hour( tomorrow morning): 200 km west southwest of iba, zambales
 48 hour(wednesday morning):350 km north northeast of pagasa island, palawan
 72 hour(thursday morning): 245 km west northwest of pagasa island, palawan
 
@@ -721,7 +721,7 @@ signal #2: metro manila, rizal, northern quezon including polillo islands, bulac
 
 signal #1 the rest of occidental mindoro, masbate including ticao island, rest of zambales, tarlac, nueva ecija, southern aurora, pangasinan, sorsogon and catanduanes
 
-please report any untoward incident to prc opcen at hotline 143; 
+please report any untoward incident to prc opcen at hotline 143;
 globe-09561481234; smart-09188076734; landline- (02) 790 2300
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[119.8828125,18.729501999072],[118.9599609375,14.987239525774],[117.9052734375,10.574222078333],[116.015625,8.1027385777832],[117.3779296875,7.2316987083671],[121.376953125,10.876464994816],[121.552734375,7.188100871179],[119.70703125,4.959615024698],[128.3203125,5.3535213553373],[126.73828125,11.867350911459],[124.0576171875,19.228176737766],[119.8388671875,19.020577110967],[119.8828125,18.729501999072]]]}","southern luzon, ncr, and  parts of central luzon",alert,actual,public,geo,immediate,moderate,observed,2016-12-25 21:55:41,2016-12-25 23:00:00,2016-12-25 21:00:00,2016-12-25 23:00:00,2016-12-25 21:51:58,2016-12-25 21:51:58
@@ -736,7 +736,7 @@ location: at 7:00 am today, the eye of typhoon was located at 60 km south of tay
 strength: max sustained winds of up to 140 kph near the center and gustiness of up to 230 kph.
 
 forecast to move west at 20 kph.
- 
+
 forecast positions:
 24 hour ( tomorrow morning): 235 km west southwest of iba, zambales
 48 hour (wednesday morning):335 km north northeast of pagasa island, palawan (outside par)
@@ -750,10 +750,10 @@ signal #2: metro manila, rizal, northern quezon including polillo islands, bulac
 
 signal #1 the rest of occidental mindoro, rest of zambales, tarlac, nueva ecija, southern aurora, pangasinan, albay and burias island
 
-please report any untoward incident to prc opcen at hotline 143; 
+please report any untoward incident to prc opcen at hotline 143;
 globe-09561481234; smart-09188076734; landline- (02) 790 2300
 
-operations center","{""type"":""Polygon"",""coordinates"":[[[120.41015625,19.228176737766],[119.3115234375,14.859850400601],[118.0810546875,10.228437266156],[116.19140625,7.8416151852047],[120.8935546875,8.4071681636011],[119.6630859375,5.0909441750334],[128.408203125,5.1784820885229],[124.0576171875,20.385825381874],[120.41015625,19.228176737766]]]}","ncr, southern luzon, bicol region and central luzon",alert,actual,public,geo,immediate,moderate,observed,2016-12-26 01:15:25,2016-12-26 02:00:00,2016-12-26 00:00:00,2016-12-26 02:00:00,2016-12-26 01:11:41,2016-12-26 01:11:41
+operations center","{""type"":""Polygon"",""coordinates"":[[[120.41015625,19.228176737766],[119.3115234375,14.859850400601],[118.0810546875,10.228437266156],[116.19140625,7.8416151852047],[120.8935546875,8.4071681636011],[119.6630859375,5.0909441750334],[128.408203125,5.1784820885229],[124.0576171875,20.385825381874],[120.41015625,19.228176737766]]]}","ncr, southern luzon, bicol subnational and central luzon",alert,actual,public,geo,immediate,moderate,observed,2016-12-26 01:15:25,2016-12-26 02:00:00,2016-12-26 00:00:00,2016-12-26 02:00:00,2016-12-26 01:11:41,2016-12-26 01:11:41
 121,165,0,PHL,en,general notifications,"severe weather bulletin no. 1 for tropical depression auring  as of 11am, january 7, 2017","[philippines red cross] the lpa has now developed into a tropical depression and was named auring.
 
 est. rainfall amount is from moderate to heavy within 300 km diameter of the tropical depression.
@@ -812,20 +812,20 @@ wave height: (open sea) 1.25-4.0 meters.
 kindly monitor and report any untoward incident to prc opcen at 09188076734; landline- (02) 790 2300
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[20.2783203125,18.895892559415],[18.9599609375,14.477234210157],[16.4990234375,7.7980785313553],[20.5859375,6.3589753272357],[20.41015625,5.1784820885229],[27.6611328125,5.1784820885229],[27.0458984375,13.710035342477],[23.1787109375,20.014645445341],[20.2783203125,18.895892559415]]]}",mindanao and visayas area,alert,actual,public,geo,immediate,moderate,observed,2017-01-07 09:28:24,2017-01-07 08:00:00,2017-01-07 08:00:00,2017-01-07 11:00:00,2017-01-07 09:24:26,2017-01-07 09:24:26
-123,96,0,NZL,en,general notifications,severe weather,"[auckland cdem] metservice advise us that this weather will continue for a while yet but will ease by dawn.  winds are gusting up to 70km/hr in some parts of the region and there are a number of power outages and trees down across auckland due to the storm. 
+123,96,0,NZL,en,general notifications,severe weather,"[auckland cdem] metservice advise us that this weather will continue for a while yet but will ease by dawn.  winds are gusting up to 70km/hr in some parts of the subnational and there are a number of power outages and trees down across auckland due to the storm.
 
-if you need help with fallen trees on roads and public areas please contact auckland council on 09 301 0101. our customer service representatives are currently working hard and will answer your call as soon as possible.  if life is in danger then please dial 111.  if you are without power, vector are working to restore power to affected communities as soon as possible.  keep a check on the website www.vector.co.nz for restoration times. ","{""type"":""Polygon"",""coordinates"":[[[174.00695800781,-36.544949441483],[174.82543945312,-36.093499373806],[175.28686523438,-36.862042695087],[175.33630371094,-37.112145754752],[174.62768554688,-37.609879943747],[174.00695800781,-36.544949441483]]]}",auckland region,alert,actual,public,geo,immediate,extreme,observed,2017-01-21 09:52:01,2017-01-21 09:00:00,2017-01-21 09:00:00,2017-01-22 11:00:00,2017-01-21 09:47:53,2017-01-21 09:47:53
+if you need help with fallen trees on roads and public areas please contact auckland council on 09 301 0101. our customer service representatives are currently working hard and will answer your call as soon as possible.  if life is in danger then please dial 111.  if you are without power, vector are working to restore power to affected communities as soon as possible.  keep a check on the website www.vector.co.nz for restoration times. ","{""type"":""Polygon"",""coordinates"":[[[174.00695800781,-36.544949441483],[174.82543945312,-36.093499373806],[175.28686523438,-36.862042695087],[175.33630371094,-37.112145754752],[174.62768554688,-37.609879943747],[174.00695800781,-36.544949441483]]]}",auckland subnational,alert,actual,public,geo,immediate,extreme,observed,2017-01-21 09:52:01,2017-01-21 09:00:00,2017-01-21 09:00:00,2017-01-22 11:00:00,2017-01-21 09:47:53,2017-01-21 09:47:53
 124,96,0,NZL,en,general notifications,earthquake between solomon islands and papua new guinea,"[auckland cdem] auckland currently no evacuation is required following the recent significant earthquake between solomon islands and papua new guinea between solomon islands and papua new guinea.
 
-* share this message * tell family and friends * listen to your radio * check for updates on twitter and facebook * 
+* share this message * tell family and friends * listen to your radio * check for updates on twitter and facebook *
 
-always remember: if you are at the coast and felt an earthquake that was too hard to stand up in or lasted longer than one minute, evacuate to high ground or as far inland as possible. 
+always remember: if you are at the coast and felt an earthquake that was too hard to stand up in or lasted longer than one minute, evacuate to high ground or as far inland as possible.
 
-what advice should i follow? 
+what advice should i follow?
 
-national warnings and threats (including marine and land) are issued by the ministry of civil defence and emergency management. 
+national warnings and threats (including marine and land) are issued by the ministry of civil defence and emergency management.
 
-auckland civil defence and emergency management uses this, and other information, to determine if evacuation is required for the auckland region.","{""type"":""Polygon"",""coordinates"":[[[173.8916015625,-36.558187766361],[174.7705078125,-36.057981047025],[175.43792724609,-35.973560753496],[175.77026367188,-36.126783233264],[175.76751708984,-36.366010258937],[175.34729003906,-36.390334862136],[175.22094726562,-36.525087702785],[175.35552978516,-37.116526184911],[174.69360351562,-37.618582632479],[173.87237548828,-36.555981536357],[173.8916015625,-36.558187766361]]]}",auckland area,alert,actual,public,geo,immediate,extreme,observed,2017-01-22 05:01:53,2017-01-22 05:00:00,2017-01-22 05:00:00,2017-01-22 09:00:00,2017-01-22 04:57:41,2017-01-22 04:57:41
+auckland civil defence and emergency management uses this, and other information, to determine if evacuation is required for the auckland subnational.","{""type"":""Polygon"",""coordinates"":[[[173.8916015625,-36.558187766361],[174.7705078125,-36.057981047025],[175.43792724609,-35.973560753496],[175.77026367188,-36.126783233264],[175.76751708984,-36.366010258937],[175.34729003906,-36.390334862136],[175.22094726562,-36.525087702785],[175.35552978516,-37.116526184911],[174.69360351562,-37.618582632479],[173.87237548828,-36.555981536357],[173.8916015625,-36.558187766361]]]}",auckland area,alert,actual,public,geo,immediate,extreme,observed,2017-01-22 05:01:53,2017-01-22 05:00:00,2017-01-22 05:00:00,2017-01-22 09:00:00,2017-01-22 04:57:41,2017-01-22 04:57:41
 125,96,0,NZL,en,general notifications,no tsunami threat,[auckland cdem] auckland - the ministry of civil defence and emergency management have confirmed that there is no tsunami threat to new zealand following a 7.9 magnitude earthquake located between the solomon islands and papua new guinea. ,"{""type"":""Polygon"",""coordinates"":[[[173.99322509766,-36.551568887374],[174.84741210938,-36.020225251548],[175.58074951172,-35.940212068887],[175.76202392578,-36.264206799345],[175.53131103516,-36.421282443649],[175.25115966797,-36.438961240859],[175.2978515625,-36.741085120944],[175.39398193359,-37.096812253687],[175.05889892578,-37.306829471249],[174.65240478516,-37.501010429493],[173.99322509766,-36.551568887374]]]}",auckland,alert,actual,public,geo,immediate,extreme,observed,2017-01-22 05:24:59,2017-01-22 05:00:00,2017-01-22 05:00:00,2017-01-22 09:00:00,2017-01-22 05:20:45,2017-01-22 05:20:45
 126,96,0,NZL,en,general notifications,polygon testing (headline),[wremo] polygon testing (message). simple polygon. change of browser,"{""type"":""Polygon"",""coordinates"":[[[165.9375,-50.254229882306],[165.1904296875,-50.993014409795],[166.10229492188,-51.371780375917],[167.4755859375,-50.923813271913],[165.9375,-50.254229882306]]]}",auckland islands,alert,test,public,other,immediate,minor,possible,2017-02-08 02:48:06,2017-02-09 02:50:00,2017-02-08 02:50:00,2017-02-10 03:30:00,2017-02-08 02:44:11,2017-02-08 02:44:11
 128,96,0,NZL,en,general notifications,test message,test message,"{""type"":""Polygon"",""coordinates"":[[[-169.365234375,-57.231502991479],[-164.70703125,-55.825973254619],[-164.35546875,-57.98480801924],[-169.365234375,-57.231502991479]]]}",test area,alert,test,public,other,expected,extreme,observed,2017-02-22 12:32:45,2017-02-23 00:00:00,2017-02-22 00:00:00,2017-02-24 00:00:00,2017-02-22 12:27:56,2017-02-22 12:27:56
@@ -869,37 +869,37 @@ yellow warning level: remaining cities and municipalities of agusan del sur and 
 flooding is possible in low-lying areas especially along river channels.
 
 please report your situation or any untoward incident to prc opcen at 09188076734, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[126.0791015625,5.5066396743549],[127.08984375,7.297087564172],[126.6064453125,9.5790843358825],[125.88134765625,10.811724143276],[124.4091796875,9.2973068563276],[123.2666015625,7.3406748318549],[123.662109375,5.1128297784995],[126.0791015625,5.5066396743549]]]}",parts of mindanao affected with the lpa,alert,actual,public,geo,immediate,moderate,observed,2017-03-06 03:53:59,2017-03-06 03:00:00,2017-03-06 03:00:00,2017-03-06 06:00:00,2017-03-06 03:48:59,2017-03-06 03:48:59
-140,96,0,NZL,en,general notifications,weather event in this area,"[auckland cdem] auckland cdem has been advised by the emergency services that they are dealing with numerous calls for assistance in the area of beachlands, maretai and kawakawa bay.  please stay off the roads in these areas as roads are flooded and many are impassable due to debris.  we are working with auckland transport to clear the roads as soon as possible.  
+140,96,0,NZL,en,general notifications,weather event in this area,"[auckland cdem] auckland cdem has been advised by the emergency services that they are dealing with numerous calls for assistance in the area of beachlands, maretai and kawakawa bay.  please stay off the roads in these areas as roads are flooded and many are impassable due to debris.  we are working with auckland transport to clear the roads as soon as possible.
 
-heavy rain will continue over the new few hours in the south auckland region.  ","{""type"":""Polygon"",""coordinates"":[[[174.97032165527,-36.865064186203],[174.94697570801,-36.941385831572],[174.97203826904,-36.985551578507],[175.03658294678,-37.019001724461],[175.09666442871,-36.981986351088],[175.12516021729,-36.932604494588],[175.10833740234,-36.881542943529],[175.06816864014,-36.870008186673],[174.99366760254,-36.858471687918],[174.97032165527,-36.865064186203]]]}",auckland region,alert,actual,public,geo,immediate,extreme,observed,2017-03-07 13:57:29,2017-03-08 13:45:00,2017-03-07 13:45:00,2017-03-07 21:00:00,2017-03-07 13:52:26,2017-03-07 13:52:26
+heavy rain will continue over the new few hours in the south auckland subnational.  ","{""type"":""Polygon"",""coordinates"":[[[174.97032165527,-36.865064186203],[174.94697570801,-36.941385831572],[174.97203826904,-36.985551578507],[175.03658294678,-37.019001724461],[175.09666442871,-36.981986351088],[175.12516021729,-36.932604494588],[175.10833740234,-36.881542943529],[175.06816864014,-36.870008186673],[174.99366760254,-36.858471687918],[174.97032165527,-36.865064186203]]]}",auckland subnational,alert,actual,public,geo,immediate,extreme,observed,2017-03-07 13:57:29,2017-03-08 13:45:00,2017-03-07 13:45:00,2017-03-07 21:00:00,2017-03-07 13:52:26,2017-03-07 13:52:26
 141,96,0,NZL,en,general notifications,localised flooding possible from heavy rain across northland,"[northland civil defence] 1515 hours: possible localised flooding later this afternoon around kaeo and ngunguru road to tutukaka coast in particular. residents are advised to make their travel plans ahead of high tide around 6pm, and keep informed before they travel, via options such as the aa roadwatch website, local radio or social media.","{""type"":""Polygon"",""coordinates"":[[[174.92431640625,-35.99578538642],[173.94653320312,-36.527294814546],[172.8369140625,-35.245619094207],[172.23266601562,-34.361576287484],[172.91381835938,-34.070862323766],[173.66088867188,-34.461277288437],[174.64965820312,-35.272531756602],[174.92431640625,-35.99578538642]]]}",northland,alert,actual,public,geo,immediate,extreme,observed,2017-03-09 02:08:41,2017-03-09 02:15:00,2017-03-09 02:15:00,2017-03-09 06:15:00,2017-03-09 02:03:41,2017-03-09 02:03:41
 142,165,0,PHL,en,general notifications,heavy rainfall warning,"[philippines red cross] weather system: tail-end of the cold front
 issued at 12:00 mn, 10 march 2017
 
 yellow warning level: davao oreintal (boston, cateel, baganga, caraga)
 
-community awareness: flooding is possible in low lying areas especially along river channels. 
+community awareness: flooding is possible in low lying areas especially along river channels.
 
 meanwhile, light to moderate rains affecting portions of surigao del norte including dinagat islands and siargao islands, surigao del sur (madrid, carmen, lanuza, cortes, lingig), davao del norte (kapalong), agusan del sur (veruela, loreto, rosario, trento), bukidnon (quezon), davao del sur (santacruz, digoscity, hagonoy), misamis oriental (gingoogcity) and nearby areas.
 
 kindly monitor and report any untoward incident to prc opcen at 09188076734; landline- (02) 790 2300
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[123.8818359375,8.8416511208091],[126.06811523438,11.005904459659],[127.72705078125,5.5066396743549],[119.93774414062,5.7690358661221],[121.83837890625,8.5484297818819],[123.8818359375,8.8416511208091]]]}",mindanao,alert,actual,public,geo,immediate,extreme,observed,2017-03-09 16:35:29,2017-03-09 16:00:00,2017-03-09 16:00:00,2017-03-09 17:00:00,2017-03-09 16:30:22,2017-03-09 16:30:22
-143,96,0,NZL,en,general notifications,prepare for more severe weather in the auckland region.,"[auckland cdem] prepare for more severe weather in the auckland region.
+143,96,0,NZL,en,general notifications,prepare for more severe weather in the auckland subnational.,"[auckland cdem] prepare for more severe weather in the auckland subnational.
 
 
-10 march 12pm 
-further bursts of heavy rain are expected in the auckland region between now and sunday. forecasts will be reviewed throughout the day.
-localised downpours are possible anywhere in the region from friday afternoon and throughout weekend, with highest risk times expected to be friday night and into saturday morning.
+10 march 12pm
+further bursts of heavy rain are expected in the auckland subnational between now and sunday. forecasts will be reviewed throughout the day.
+localised downpours are possible anywhere in the subnational from friday afternoon and throughout weekend, with highest risk times expected to be friday night and into saturday morning.
 downpours can cause flash flooding, land slips, and make driving hazardous.
 
-metservice tells us that weather coming through tonight and tomorrow morning could be as bad, or worse, than that which caused flooding earlier in the week. with such volatile weather patterns, we cannot pinpoint the areas that will be most affected. 
+metservice tells us that weather coming through tonight and tomorrow morning could be as bad, or worse, than that which caused flooding earlier in the week. with such volatile weather patterns, we cannot pinpoint the areas that will be most affected.
 
 this makes it very important for all aucklanders to keep an eye on weather updates and make sensible decisions this weekend
 
 preparedness
-•	check drains and gutters to ensure these aren’t blocked. 
-•	take extreme care if you are driving in heavy rain, and delay trips if possible. 
+•	check drains and gutters to ensure these aren’t blocked.
+•	take extreme care if you are driving in heavy rain, and delay trips if possible.
 •	do not drive through floodwaters.
 •	consider alternative plans if you have an outdoor event scheduled this weekend.
 •	if you live on a rural property, think about livestock rotation for the weekend, especially if areas of your farms are flood-prone.
@@ -909,12 +909,12 @@ preparedness
 
 follow www.facebook.com/aklcdem and twitter @aucklandcdem for updates.
 ","{""type"":""Polygon"",""coordinates"":[[[174.73205566406,-36.129001655697],[174.07287597656,-36.456636011596],[174.74304199219,-37.579412513438],[175.35827636719,-37.059560830251],[175.11108398438,-36.514051199432],[175.54504394531,-36.394756699874],[175.75378417969,-36.089060460282],[175.24841308594,-35.986896284438],[174.73205566406,-36.129001655697]]]}",auckland,alert,actual,public,geo,immediate,extreme,observed,2017-03-09 23:13:42,2017-03-09 23:00:00,2017-03-09 22:00:00,2017-03-11 11:00:00,2017-03-09 23:08:38,2017-03-09 23:08:38
-144,96,0,NZL,en,general notifications,prepare for more severe weather in the auckland region,"[auckland cdem] prepare for more severe weather in the auckland region
+144,96,0,NZL,en,general notifications,prepare for more severe weather in the auckland subnational,"[auckland cdem] prepare for more severe weather in the auckland subnational
 
-further bursts of heavy rain are expected in the auckland region between now and sunday.
-localised downpours are possible anywhere in the region from friday and throughout the weekend, with the highest risk times expected to be friday night and into saturday morning.
+further bursts of heavy rain are expected in the auckland subnational between now and sunday.
+localised downpours are possible anywhere in the subnational from friday and throughout the weekend, with the highest risk times expected to be friday night and into saturday morning.
 downpours can cause flash flooding, land slips, and make driving hazardous.
-metservice tells us that weather coming through tonight and tomorrow morning could be as bad, or worse, than that which caused flooding earlier in the week. with such volatile weather patterns, we can’t pinpoint the areas that will be most affected. 
+metservice tells us that weather coming through tonight and tomorrow morning could be as bad, or worse, than that which caused flooding earlier in the week. with such volatile weather patterns, we can’t pinpoint the areas that will be most affected.
 preparedness
 •	check your drains and gutters to ensure these aren’t blocked
 •	take extreme care if you are driving in heavy rain, and delay trips if possible.
@@ -927,25 +927,25 @@ watercare urges aucklanders to reduce water use
 water treatment at watercare’s ardmore plant has been slowed down to manage the amount of silt coming into the plant in water from its dams. as a result, watercare is asking aucklanders to reduce their water use by 20 litres (two buckets) per day. read more on watercare’s website.
 
 keep up to date on facebook www.facebook.com/aklcdem/ or twitter @aucklandcdem","{""type"":""Polygon"",""coordinates"":[[[175.18798828125,-35.9157474195],[173.98498535156,-36.500805317605],[174.69909667969,-37.57505900515],[175.38024902344,-37.02448395076],[175.29235839844,-36.606708886418],[175.22644042969,-36.425702520392],[175.57250976562,-36.385912772877],[175.83618164062,-36.30627216958],[175.45166015625,-35.991340960635],[175.18798828125,-35.9157474195]]]}",auckland,alert,actual,public,geo,immediate,extreme,observed,2017-03-10 03:12:32,2017-03-10 03:30:00,2017-03-10 03:30:00,2017-03-11 11:00:00,2017-03-10 03:07:28,2017-03-10 03:07:28
-145,96,0,NZL,en,general notifications,storm update -  wind warning for auckland region,"[auckland cdem] storm update | wind warning for auckland region
+145,96,0,NZL,en,general notifications,storm update -  wind warning for auckland subnational,"[auckland cdem] storm update | wind warning for auckland subnational
 
-more severe weather is likely to hit the auckland region in the next 24 hours and aucklanders are urged to be prepared. 
-the intense weather is not over yet and high winds are expected to hit the region tomorrow morning, bringing further disruption. 
-high winds may bring trees and powerlines down. power companies are already managing some outages and are on standby for tomorrow. 
-heavy rain and strong winds are forecast to return to the region between about 7am and 2pm, give or take.
+more severe weather is likely to hit the auckland subnational in the next 24 hours and aucklanders are urged to be prepared.
+the intense weather is not over yet and high winds are expected to hit the subnational tomorrow morning, bringing further disruption.
+high winds may bring trees and powerlines down. power companies are already managing some outages and are on standby for tomorrow.
+heavy rain and strong winds are forecast to return to the subnational between about 7am and 2pm, give or take.
 the worst of the wind and rain should occur around noon or in the early afternoon and localised gusts of 120 km/hr are possible.
 “in addition, there is a low risk of small tornadoes in coastal locations
-what does this mean for you? 
+what does this mean for you?
 •	secure outdoor furniture and items
 •	have a torch and battery-operated radio handy in case of power outages
 •	avoid travel if possible. if you must go out, drive to the conditions – look out for debris and never drive through floodwater
 •	bring pets inside overnight
 •	consider closing curtains if windows may be broken by trees or debris
 •	look out for neighbours and check on any that need help.
-if life or property is at risk, call 111. if you experience stormwater issues or trees down on public land, call auckland council on (09) 301 0101. council and emergency services are experiencing high call volumes so please be patient or call again later if your matter is not urgent. 
+if life or property is at risk, call 111. if you experience stormwater issues or trees down on public land, call auckland council on (09) 301 0101. council and emergency services are experiencing high call volumes so please be patient or call again later if your matter is not urgent.
 additional information
 watercare urges aucklanders to reduce water use
-water treatment at watercare’s ardmore plant has been slowed down to manage the amount of silt coming into the plant in water from its dams. as a result, watercare is asking aucklanders to reduce their water use by 20 litres (two buckets) per day. read more on watercare’s website.  
+water treatment at watercare’s ardmore plant has been slowed down to manage the amount of silt coming into the plant in water from its dams. as a result, watercare is asking aucklanders to reduce their water use by 20 litres (two buckets) per day. read more on watercare’s website.
 ","{""type"":""Polygon"",""coordinates"":[[[174.83093261719,-36.075742215627],[174.09484863281,-36.452217696436],[174.70458984375,-37.561996953144],[175.37475585938,-37.085857852637],[175.19348144531,-36.50963615733],[175.166015625,-36.390334862136],[175.78674316406,-36.363798554159],[175.61645507812,-35.964669147704],[174.83093261719,-36.075742215627]]]}",auckland,alert,actual,public,geo,immediate,extreme,observed,2017-03-11 03:20:52,2017-03-11 03:30:00,2017-03-11 03:30:00,2017-03-12 11:00:00,2017-03-11 03:15:48,2017-03-11 03:15:48
 146,165,0,PHL,en,general notifications,heavy rainfall warning no. 1 due tail-end of a cold front,"[philippines red cross] weather system: tail-end of a cold front
 issued at 4:10 pm, 11 march 2017
@@ -957,7 +957,7 @@ flooding is possible in low lying areas and landslides in mountainous areas.
 meanwhile, light to moderate rains affecting portions of zamboanga del norte, surigao del norte including dinagat islands, agusan del norte, misamis oriental, lanao del norte, misamis occidental, compostela valley, davao city, north cotabato, davao oriental as well as other cities and municipalities of bukidnon, agusan del sur and surigao del sur.
 
 please report your situation or any untoward incidents to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[126.5625,6.3043787643258],[126.96899414062,7.9069116164693],[126.73828125,9.654907854199],[125.69458007812,10.152746165572],[125.70556640625,10.595820834654],[125.2880859375,10.2176253532],[124.8486328125,9.2973068563276],[121.48681640625,7.7327650627298],[119.2236328125,4.9815050493282],[120.21240234375,4.5764249358537],[123.25561523438,7.1990007237288],[125.771484375,4.6859295066063],[126.5625,6.3043787643258]]]}",mindanao areas affected by tail end of cold front,alert,actual,public,geo,immediate,moderate,observed,2017-03-11 09:11:41,2017-03-11 08:00:00,2017-03-11 08:00:00,2017-03-13 11:00:00,2017-03-11 09:06:26,2017-03-11 09:06:26
-147,96,0,NZL,en,general notifications,significant weather event in west auckland,"[auckland cdem] there is currently heavy rain and associated flooding in the west area of auckland region.
+147,96,0,NZL,en,general notifications,significant weather event in west auckland,"[auckland cdem] there is currently heavy rain and associated flooding in the west area of auckland subnational.
 
 emergency services are responding to calls and there are significant delays in call queues. please call 111 only as appropriate.
 
@@ -982,18 +982,18 @@ operations center","{""type"":""Polygon"",""coordinates"":[[[122.08557128906,14.
 
 the monitored lpa was estimated around 700 km east of northern mindanao.
 
-beginning early morning tomorrow, northern mindanao & eastern visayas area will have moderate to occasionally heavy rains. residents along the provinces of surigao, leyte and samar must stay alert for possible flash flood and landslides. 
+beginning early morning tomorrow, northern mindanao & eastern visayas area will have moderate to occasionally heavy rains. residents along the provinces of surigao, leyte and samar must stay alert for possible flash flood and landslides.
 
 the rest of mindanao and the rest of visayas will have occasional rains and scattered thunderstorms late today and tomorrow.
 
-please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.5517578125,13.047372256949],[123.1787109375,12.597454504832],[120.76171875,11.329253026617],[120.8935546875,7.3188817303668],[119.5751953125,5.3753977744747],[119.77294921875,3.9519408561576],[123.50830078125,7.035475652433],[124.43115234375,4.9158328013132],[126.45263671875,5.0252829086093],[127.41943359375,7.5803277913301],[125.5517578125,13.047372256949]]]}",visayas and mindanao region,alert,actual,public,geo,immediate,moderate,observed,2017-03-19 03:49:14,2017-03-19 03:00:00,2017-03-19 03:00:00,2017-03-19 08:00:00,2017-03-19 03:44:00,2017-03-19 03:44:00
+please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.5517578125,13.047372256949],[123.1787109375,12.597454504832],[120.76171875,11.329253026617],[120.8935546875,7.3188817303668],[119.5751953125,5.3753977744747],[119.77294921875,3.9519408561576],[123.50830078125,7.035475652433],[124.43115234375,4.9158328013132],[126.45263671875,5.0252829086093],[127.41943359375,7.5803277913301],[125.5517578125,13.047372256949]]]}",visayas and mindanao subnational,alert,actual,public,geo,immediate,moderate,observed,2017-03-19 03:49:14,2017-03-19 03:00:00,2017-03-19 03:00:00,2017-03-19 08:00:00,2017-03-19 03:44:00,2017-03-19 03:44:00
 151,165,0,PHL,en,general notifications,"pagasa weather forecast as of 5pm, 19 march 2017","[philippines red cross] synopsis: at 4:00 pm today, the lpa was estimated at 440 km east of hinatuan, surigao del sur. northeast monsoon affecting northern luzon.
 
-forecast: regions of caraga and davao-- cloudy skies with moderate to occasionally heavy rains and thunderstorms.
+forecast: subnationals of caraga and davao-- cloudy skies with moderate to occasionally heavy rains and thunderstorms.
 
 eastern visayas-- cloudy skies with light to moderate rains and isolated thunderstorms.
 
-regions of ilocos, cagayan valley and cordillera-- partly cloudy to cloudy skies with isolated light rains. 
+subnationals of ilocos, cagayan valley and cordillera-- partly cloudy to cloudy skies with isolated light rains.
 metro manila and the rest of the country-- partly cloudy to cloudy skies with isolated rainshowers or thunderstorms.
 
 please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300
@@ -1014,7 +1014,7 @@ at 10:00 am today, the lpa was at 230 km east southeast of guiuan, eastern samar
 
 this will bring moderate to occasionally heavy rains and thunderstorms over eastern visayas and the provinces of surigao del norte and dinagat. flashfloods and landslides might occur in these areas.
 
- the rest of visayas, bicol region, northern mindanao and the rest of caraga will experience cloudy skies with light to moderate rains and isolated thunderstorms.
+ the rest of visayas, bicol subnational, northern mindanao and the rest of caraga will experience cloudy skies with light to moderate rains and isolated thunderstorms.
 
 everyone is advised to prepare, stay alert and monitor news for updates. please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[121.5966796875,21.248422235627],[119.1796875,15.580710739162],[113.90625,11.393879232967],[114.345703125,9.1888700844734],[116.103515625,7.4060477170763],[118.388671875,7.3188817303668],[120.8935546875,5.3535213553373],[123.837890625,5.0033943450221],[126.123046875,5.0471707369197],[127.529296875,6.0968598188879],[127.44140625,11.307707707765],[127.08984375,14.136575651478],[123.310546875,19.642587534013],[121.5966796875,21.248422235627]]]}",whole country,alert,actual,public,geo,immediate,moderate,observed,2017-03-20 04:13:58,2017-03-20 03:00:00,2017-03-20 03:00:00,2017-03-20 08:00:00,2017-03-20 04:08:42,2017-03-20 04:08:42
 154,165,0,PHL,en,general notifications,heavy rainfall warning no.3 due to lpa,"[philippines red cross] issued at 1:20 pm, 20 march 2017
@@ -1035,13 +1035,13 @@ flooding is possible in low lying areas and landslide in mountainous areas.
 
 heavy rainfall advisory for mindanao area is already terminated.
 
-everyone is advised to stay alert and monitor news for updates. you can report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.36499023438,9.8281544584768],[125.3759765625,10.671404468527],[126.32080078125,11.01668852446],[125.771484375,12.340001834116],[124.892578125,12.940322128385],[124.16748046875,12.651058133703],[124.1455078125,11.490790980367],[124.22241210938,10.433793243184],[124.92553710938,9.7848512507506],[125.36499023438,9.8281544584768]]]}",eastern visayas region,alert,actual,public,geo,immediate,extreme,observed,2017-03-20 08:57:02,2017-03-20 08:20:00,2017-03-20 08:20:00,2017-03-20 11:20:00,2017-03-20 08:51:47,2017-03-20 08:51:47
+everyone is advised to stay alert and monitor news for updates. you can report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.36499023438,9.8281544584768],[125.3759765625,10.671404468527],[126.32080078125,11.01668852446],[125.771484375,12.340001834116],[124.892578125,12.940322128385],[124.16748046875,12.651058133703],[124.1455078125,11.490790980367],[124.22241210938,10.433793243184],[124.92553710938,9.7848512507506],[125.36499023438,9.8281544584768]]]}",eastern visayas subnational,alert,actual,public,geo,immediate,extreme,observed,2017-03-20 08:57:02,2017-03-20 08:20:00,2017-03-20 08:20:00,2017-03-20 11:20:00,2017-03-20 08:51:47,2017-03-20 08:51:47
 156,165,0,PHL,en,general notifications,weather  advisory for low pressure area,"[philippines red cross] weather  advisory #3 issued at 11:00 am, 21 march 2017
 for: low pressure area
 
 at 10:00 am today, the low pressure area (lpa) is in the vicinity of aroroy, masbate. this weather disturbance will bring moderate to occasionally heavy rains and isolated thunderstorms over the provinces of mindoro, marinduque, romblon, camarines norte and southern quezon. residents in these areas are alerted for possible flashfloods and landslides until this evening.
 
-meanwhile, the rest of calabarzon and bicol region will experience cloudy skies with light to moderate rains and isolated thunderstorms.
+meanwhile, the rest of calabarzon and bicol subnational will experience cloudy skies with light to moderate rains and isolated thunderstorms.
 
 kindly monitor and report any untoward incident to prc opcen at 09188076734; landline- (02) 790 2300
 
@@ -1053,9 +1053,9 @@ orange warning level: camarines norte
 
 flooding is possible in low lying areas & areas near river channels; landslides also possible in mountainous areas.
 
-meanwhile, there is a thunderstorm affecting marinduque, oriental mindoro and portions of camarines sur (naga city milaor, libmanan, pamplona, sipocot, and nearby areas). 
+meanwhile, there is a thunderstorm affecting marinduque, oriental mindoro and portions of camarines sur (naga city milaor, libmanan, pamplona, sipocot, and nearby areas).
 
-all are advised to take precautionary measures against heavy rains, strong winds, lightning and possible flashfloods & landslides. 
+all are advised to take precautionary measures against heavy rains, strong winds, lightning and possible flashfloods & landslides.
 
 kindly monitor and report any untoward incident to prc opcen at 09188076734; landline- (02) 790 2300
 
@@ -1080,10 +1080,10 @@ please report your situation or any untoward incident to prc opcen at 0956148123
 161,96,0,NZL,en,general notifications,northland tsunami siren testing tomorrow sunday 2 april,"[northland civil defence] 1710 hrs sat 1 apr: northland tsunami sirens will be tested tomorrow from 0920. if you live, work on or visit the coast, please check out the siren sound, whether you're in an evacuation zone and evacuation routes - more info on our facebook page.","{""type"":""Polygon"",""coordinates"":[[[174.83642578125,-36.022446681758],[173.9794921875,-36.50963615733],[171.826171875,-34.16181816123],[173.14453125,-34.125447565116],[174.58374023438,-34.894942447397],[174.83642578125,-36.022446681758]]]}",northland,alert,actual,public,geo,immediate,extreme,observed,2017-04-01 04:08:51,2017-04-01 21:20:00,2017-04-01 04:10:00,2017-04-01 20:30:00,2017-04-01 04:03:19,2017-04-01 04:03:19
 162,96,0,NZL,en,general notifications,northland tsunami siren testing from 0920 hrs today sunday 2 april,"[northland civil defence] 0840 hrs sun 2 apr: northland tsunami sirens tested today from 0920 hrs and again at 1000. please check out the sound, evacuation zones and routes - more info on our facebook page. and encourage others to download the hazard app.","{""type"":""Polygon"",""coordinates"":[[[174.97924804688,-35.991340960635],[173.8916015625,-36.531708849149],[172.05139160156,-34.329828328362],[173.11157226562,-34.21180215769],[174.51782226562,-34.93998515156],[174.97924804688,-35.991340960635]]]}",northland,alert,actual,public,geo,immediate,extreme,observed,2017-04-01 20:32:10,2017-04-01 21:20:00,2017-04-01 20:40:00,2017-04-02 00:00:00,2017-04-01 20:29:15,2017-04-01 20:29:15
 163,96,0,NZL,en,general notifications,test only hbcdem regional public alert systems test,"[hawkes bay cdem] hbcdem regional public alert systems test, from 11.50am today","{""type"":""Polygon"",""coordinates"":[[[178.02795410156,-38.856820134744],[178.02795410156,-39.381018032945],[177.43469238281,-39.138581990584],[176.94580078125,-39.41922073656],[177.17651367188,-39.698734143481],[176.65466308594,-40.509622849597],[176.25915527344,-40.287906612507],[176.58874511719,-39.859154792957],[176.65466308594,-39.431950321169],[176.98974609375,-39.002110299225],[177.35229492188,-38.963680101986],[178.02795410156,-38.856820134744]]]}",hawke's bay new zealand,alert,test,public,geo,immediate,extreme,observed,2017-04-01 23:56:54,2017-04-01 23:55:00,2017-04-01 23:55:00,2017-04-02 00:05:00,2017-04-01 23:51:22,2017-04-01 23:51:22
-164,96,0,NZL,en,general notifications,auckland cdem test message,"[auckland cdem] this is a test message by auckland civil defence and emergency management as part of our twice yearly checks of all public alerting systems, including email, sms, social media and the 44 fixed tsunami warning sirens across rodney and waitakere areas.  
+164,96,0,NZL,en,general notifications,auckland cdem test message,"[auckland cdem] this is a test message by auckland civil defence and emergency management as part of our twice yearly checks of all public alerting systems, including email, sms, social media and the 44 fixed tsunami warning sirens across rodney and waitakere areas.
 
-you will receive alerts from auckland civil defence when we need you to be aware of an emergency or hazard and take action.  
-sign up to our sms and email updates by visiting www.aucklandicivildefence.org.nz and clicking on subscribe.  
+you will receive alerts from auckland civil defence when we need you to be aware of an emergency or hazard and take action.
+sign up to our sms and email updates by visiting www.aucklandicivildefence.org.nz and clicking on subscribe.
 
 the next test of this system will take place on 24 september 2017 at 12pm.","{""type"":""Polygon"",""coordinates"":[[[174.6826171875,-37.618582632479],[174.91333007812,-37.527153617234],[175.05065917969,-37.426888345267],[175.06713867188,-37.269681509697],[175.2978515625,-37.142803443717],[175.39123535156,-37.055177106661],[175.23742675781,-36.562600037385],[175.2099609375,-36.363798554159],[175.58898925781,-36.421282443649],[175.76477050781,-36.244273184939],[175.66589355469,-36.075742215627],[175.52307128906,-35.951329861523],[175.35827636719,-35.924644531441],[175.23742675781,-35.955776540565],[175.11657714844,-36.018003758714],[174.90783691406,-36.089060460282],[174.66613769531,-36.129001655697],[174.01245117188,-36.505220863384],[174.6826171875,-37.618582632479]]]}",auckland,alert,actual,public,geo,immediate,extreme,observed,2017-04-01 23:55:19,2017-04-02 00:05:00,2017-04-02 00:01:00,2017-04-04 03:00:00,2017-04-01 23:53:03,2017-04-01 23:53:03
 165,165,0,PHL,en,general notifications,heavy rainfall warning as of 1:40 pm 02 april 2017‬‬‬‬‬‬‬‬‬‬‬‬,"[philippines red cross] heavy rainfall warning as of 1:40 pm 02 april 2017‬‬‬‬‬‬‬‬‬‬‬‬
@@ -1092,7 +1092,7 @@ weather system: easterlies
 yellow warning level: surigao del norte, surigao del sur, davao oriental, agusan del sur
 flooding is possible especially in low-lying areas and along river channels.
 ‬‬
-meanwhile, light to moderate rains affecting agusan del norte (butuan, bayugan), misamis oriental (gongoog, lurisa), bukidnon (impasug 
+meanwhile, light to moderate rains affecting agusan del norte (butuan, bayugan), misamis oriental (gongoog, lurisa), bukidnon (impasug
 
 ong,baungon,kibawe,quezon,loreto), north cotabato (matalam, arakan, kidapawan), davao del norte (panabo,carmen), lanao del sur
 
@@ -1134,7 +1134,7 @@ flooding is possible especially in low-lying areas along river channels.",alert,
 168,165,0,PHL,en,general notifications,heavy rainfall warning due to tail end of a cold front,"[philippines red cross] heavy rainfall warning no. 1
 issued at 8am, 04 april 2017
 
-orange warning: southernleyte, southern portions of eastern samar and samar; 
+orange warning: southernleyte, southern portions of eastern samar and samar;
 flooding is threatening in low lying areas and landslides in mountainous areas
 
 yellow warning: leyte
@@ -1143,7 +1143,7 @@ flooding is possible in low lying areas and landslides in mountainous areas.
 all are advised to take precautionary measures.
 
 please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.16723632812,9.8173291870678],[125.51879882812,10.574222078333],[125.5517578125,10.95197822139],[125.83740234375,12.275598890562],[124.77172851562,12.876069959947],[124.11254882812,12.468760144823],[124.11254882812,11.350796722384],[124.85961914062,9.6657383951887],[125.16723632812,9.8173291870678]]]}",eastern visayas,alert,actual,public,geo,immediate,moderate,observed,2017-04-04 01:28:42,2017-04-04 00:00:00,2017-04-04 00:00:00,2017-04-04 03:00:00,2017-04-04 01:23:09,2017-04-04 01:23:09
-169,165,0,PHL,en,general notifications,heavy rainfall warning no.2 due to tail end of a cold front,"[philippines red cross] heavy rainfall warning no.2 
+169,165,0,PHL,en,general notifications,heavy rainfall warning no.2 due to tail end of a cold front,"[philippines red cross] heavy rainfall warning no.2
 issued at: 9:10 am, 04 april 2017
 
 orange warning: cebu, bohol, southern leyte, leyte,  southern portion of samar and of eastern samar.
@@ -1156,7 +1156,7 @@ please report your situation or any untoward incident to prc opcen at 0956148123
 170,165,0,PHL,en,general notifications,weather advisory no. 1 for  tail-end of a cold front,"[philippines red cross] weather advisory no. 1
 issued at: 11:00 am, 04 april 4, 2017
 
-the tail-end of a cold front will bring moderate to occasionally heavy rains and thunderstorms over the regions of eastern and central visayas and caraga. residents in these areas are alerted against possible flashfloods and landslides.
+the tail-end of a cold front will bring moderate to occasionally heavy rains and thunderstorms over the subnationals of eastern and central visayas and caraga. residents in these areas are alerted against possible flashfloods and landslides.
 
 meanwhile, the rest of visayas and rest of mindanao will experience cloudy skies with light to moderate rains and isolated thunderstorms.
 
@@ -1215,12 +1215,12 @@ ito ay panawagan na maging handa sa anumang sakuna tulad ng lindol, bagyo, baha,
 philippine red cross operations center","{""type"":""Polygon"",""coordinates"":[[[126.14501953125,5.2222465132274],[127.3974609375,7.6674414827261],[126.1669921875,12.211180191504],[124.0576171875,15.093339268117],[122.80517578125,15.60187487674],[123.24462890625,19.207428526801],[120.8935546875,20.055931265194],[118.85009765625,16.509832826906],[119.64111328125,13.154376055419],[116.65283203125,8.9067800075202],[116.3671875,7.4496242601978],[118.4326171875,7.4496242601978],[120.498046875,10.725381285458],[122.0361328125,8.8199389282831],[119.81689453125,6.2279339302687],[119.091796875,4.3902289264634],[121.13525390625,4.1711154548674],[123.3984375,6.4681510126642],[125.2880859375,4.6092780844098],[126.14501953125,5.2222465132274]]]}",whole philippines,alert,actual,public,geo,immediate,extreme,observed,2017-04-09 10:38:12,2017-04-09 10:00:00,2017-04-09 10:00:00,2017-04-09 12:00:00,2017-04-09 10:32:35,2017-04-09 10:32:35
 176,96,0,NZL,en,general notifications,test message from waimakariri district,[waimak cdem] this is a test message only; please ignore it.,"{""type"":""Polygon"",""coordinates"":[[[172.72155761719,-43.287202684804],[172.51419067383,-43.202172739902],[172.11456298828,-43.124040844124],[172.0458984375,-43.347152360033],[172.32330322266,-43.452918893555],[172.71057128906,-43.390079909155],[172.72155761719,-43.287202684804]]]}",waimakariri district in north canterbury,alert,test,public,geo,immediate,extreme,observed,2017-04-10 23:48:21,2017-04-10 23:50:00,2017-04-10 23:49:00,2017-04-10 23:51:00,2017-04-10 23:42:39,2017-04-10 23:42:39
 177,96,0,NZL,en,general notifications,extreme weather heading for great barrier islands,"[auckland cdem] morning residents of gbi,
-extreme rainfall today (wednesday) and tomorrow will hit great barrier island prior to the arrival of tropical cyclone cook. 
-barrier residents are urged to prepare for bursts of heavy rain and localised deluges over the next two days. this will be followed by the arrival of tc cook on thursday which is expected to bring more intense rain and extremely high winds of up to 165-plus kmph. 
-current forecasts show the cyclone arriving around midday thursday however keep an eye on updated forecasts throughout the day as this may change. 
+extreme rainfall today (wednesday) and tomorrow will hit great barrier island prior to the arrival of tropical cyclone cook.
+barrier residents are urged to prepare for bursts of heavy rain and localised deluges over the next two days. this will be followed by the arrival of tc cook on thursday which is expected to bring more intense rain and extremely high winds of up to 165-plus kmph.
+current forecasts show the cyclone arriving around midday thursday however keep an eye on updated forecasts throughout the day as this may change.
 metservice believe that this weather event is going to be potentially more severe than anything seen in recent times. we expect the islands to experience landslides, flooding of low lying areas. some communities may be isolated. ensure that you have sufficient supplies and medication to last the easter weekend.
-the rain, combined with severe wind and coastal storm surge, could create extreme impacts for great barrier island. islanders need to brace themselves for some of the most severe weather they’ve seen in recent times. residents please spend today planning for this incoming weather and making sure your property is secured, stock moved, and gutters and drains cleared. if your property is at risk of flooding or slips, consider ahead of time whether you need to stay with friends or family for the duration of this storm event. 
-if there is an immediate risk to life or property at any time, contact emergency services on 111. 
+the rain, combined with severe wind and coastal storm surge, could create extreme impacts for great barrier island. islanders need to brace themselves for some of the most severe weather they’ve seen in recent times. residents please spend today planning for this incoming weather and making sure your property is secured, stock moved, and gutters and drains cleared. if your property is at risk of flooding or slips, consider ahead of time whether you need to stay with friends or family for the duration of this storm event.
+if there is an immediate risk to life or property at any time, contact emergency services on 111.
 travel
 •	consider postponing non-essential travel both on the island and to and from great barrier island
 •	visit sealink for the most up to date ferry schedules and information.
@@ -1230,18 +1230,18 @@ on the island
 •	if you get stuck in a flood, get out of your car and move to higher ground immediately, taking great care in the floodwaters.
 •	if driving at night, drive slowly, especially through flood-prone areas as you may encounter flooding at short notice.
 •	if your property or area may be affected by slips or power outages, prepare for the possibility that your road access may be cut off and ensure you have food and provisions on hand in case of isolation.
-•	never attempt to drive over slips and treat power lines as live at all times. 
+•	never attempt to drive over slips and treat power lines as live at all times.
 •	report blocked drains, flooding and trees down on public land to the council on 09 301 0101.
 check on neighbours and family, especially if they are in at risk areas or might be affected by flooding or slips.
 please take care and keep an eye on your community.
 ","{""type"":""Polygon"",""coordinates"":[[[175.41320800781,-36.015782203258],[175.02593994141,-36.177791083291],[175.0341796875,-36.2354121684],[175.54779052734,-36.377067839837],[175.58898925781,-36.301845303684],[175.58898925781,-36.117908916564],[175.41320800781,-36.015782203258]]]}",great barrier islands,alert,actual,public,geo,immediate,extreme,observed,2017-04-11 22:40:00,2017-04-11 22:40:00,2017-04-11 22:40:00,2017-04-14 06:00:00,2017-04-11 22:34:27,2017-04-11 22:34:27
-178,96,0,NZL,en,general notifications,significant weather event heading to waiheke island and auckland region.,"[auckland cdem] morning waiheke,
-extreme rainfall today (wednesday) and tomorrow will hit the gulf islands and is likely to impact waiheke prior to the arrival of tropical cyclone cook. 
-residents in waiheke are urged to prepare for bursts of heavy rain and localised deluges over the next two days. this will be followed by the arrival of tc cook on thursday which is expected to bring more intense rain and extremely high winds of up to 165-plus kmph. tc cook will pass close to waiheke and auckland region.
-current forecasts show the cyclone arriving around midday thursday however keep an eye on updated forecasts throughout the day as this may change. 
+178,96,0,NZL,en,general notifications,significant weather event heading to waiheke island and auckland subnational.,"[auckland cdem] morning waiheke,
+extreme rainfall today (wednesday) and tomorrow will hit the gulf islands and is likely to impact waiheke prior to the arrival of tropical cyclone cook.
+residents in waiheke are urged to prepare for bursts of heavy rain and localised deluges over the next two days. this will be followed by the arrival of tc cook on thursday which is expected to bring more intense rain and extremely high winds of up to 165-plus kmph. tc cook will pass close to waiheke and auckland subnational.
+current forecasts show the cyclone arriving around midday thursday however keep an eye on updated forecasts throughout the day as this may change.
 metservice believe that this weather event is going to be potentially more severe than anything seen in recent times. we expect the islands to experience landslides, flooding of low lying areas. some communities could become isolated. ensure that you have sufficient supplies and medication to last the easter weekend.
-the rain, combined with severe wind and coastal storm surge, could create significant impacts for waiheke island. islanders need to brace themselves for some severe weather. residents please spend today planning for this incoming weather and making sure your property is secured, stock moved, and gutters and drains cleared. if your property is at risk of flooding or slips, consider ahead of time whether you need to stay with friends or family for the duration of this storm event. 
-if there is an immediate risk to life or property at any time, contact emergency services on 111. 
+the rain, combined with severe wind and coastal storm surge, could create significant impacts for waiheke island. islanders need to brace themselves for some severe weather. residents please spend today planning for this incoming weather and making sure your property is secured, stock moved, and gutters and drains cleared. if your property is at risk of flooding or slips, consider ahead of time whether you need to stay with friends or family for the duration of this storm event.
+if there is an immediate risk to life or property at any time, contact emergency services on 111.
 travel
 •	consider postponing non-essential travel both on the island and to and from waiheke island.
 •	visit fullers and sea link websites for the most up to date ferry schedules and information.
@@ -1251,54 +1251,54 @@ on the island
 •	if you get stuck in a flood, get out of your car and move to higher ground immediately, taking great care in the floodwaters.
 •	if driving at night, drive slowly, especially through flood-prone areas as you may encounter flooding at short notice.
 •	if your property or area may be affected by slips or power outages, prepare for the possibility that your road access may be cut off and ensure you have food and provisions on hand in case of isolation.
-•	never attempt to drive over slips and treat power lines as live at all times. 
+•	never attempt to drive over slips and treat power lines as live at all times.
 •	report blocked drains, flooding and trees down on public land to the council on 09 301 0101.
 check on neighbours and family, especially if they are in at risk areas or might be affected by flooding or slips.
 
 please take care and keep an eye on your community.","{""type"":""Polygon"",""coordinates"":[[[174.81582641602,-36.758690821098],[174.95727539062,-36.695952078717],[175.21682739258,-36.741085120944],[175.24429321289,-36.88511287236],[175.18936157227,-36.916960231833],[175.04104614258,-36.840064620378],[174.82406616211,-36.824676208856],[174.81582641602,-36.758690821098]]]}",waiheke island,alert,actual,public,geo,immediate,extreme,observed,2017-04-11 22:59:29,2017-04-11 22:59:00,2017-04-11 22:59:00,2017-04-14 06:00:00,2017-04-11 22:53:47,2017-04-11 22:53:47
 179,96,0,NZL,en,general notifications,urgent advice 12 april 2017 | kawakawa bay residents,"[auckland cdem] morning residents of kawakawa bay,
-extreme rainfall today (wednesday) and tomorrow will hit the auckland region and is likely to significantly impact kawakawa bay prior to the arrival of tropical cyclone cook. 
- 
-advice for kawakawa bay residents and orere point residents: 
-a significant storm event, followed by the arrival of tropical cyclone cook, is highly likely to bring extreme weather – with significant rainfall and high winds – to the south eastern part of the auckland region. 
-communities in the kawakawa bay and orere point area, particularly those towards the waiti bay end of kawakawa bay coast road, are expected to again be isolated by road and without power or phone for a substantial amount of time. 
-waiti bay residents only – consider alternative accommodation. 
-auckland civil defence strongly recommends that residents in the waiti bay area look at alternative accommodation for the next few days and potentially for longer. 
-should you choose to stay, you may be isolated for some time while power, phone and access is restored. make sure you are prepared. 
-general advice 
-•	never attempt to drive over slips and treat power lines as live at all times. 
-•	if there is an immediate risk to life or property contact the emergency services on 111. 
-•	check on neighbours and family, especially if they are in at risk areas or might be affected by flooding or slips. 
-•	move away from flooded areas and stay out of floodwaters. 
-•	never try to walk, swim, or drive through floodwaters. 
-•	if you get stuck in a flood, get out of your car and move to higher ground immediately, taking great care in the floodwaters. 
-•	if driving at night, drive slowly, especially through flood-prone areas as you may encounter flooding at short notice. 
+extreme rainfall today (wednesday) and tomorrow will hit the auckland subnational and is likely to significantly impact kawakawa bay prior to the arrival of tropical cyclone cook.
 
-insurance: once the storm is over or it is safe to return home, contact your insurance company. if possible, take photos of damage. 
-take good care of yourself: recovering from a major storm is a big job. it is tough on both your body and your spirit. learn how to recognise and care for anxiety, stress and fatigue. 
-if you can’t live in your house due to flooding, slips, lack of access or extreme damage to you, try and stay with family or friends. if you can’t, auckland council may be able to assist, contact us on 0800 22 22 00 for further support.	
+advice for kawakawa bay residents and orere point residents:
+a significant storm event, followed by the arrival of tropical cyclone cook, is highly likely to bring extreme weather – with significant rainfall and high winds – to the south eastern part of the auckland subnational.
+communities in the kawakawa bay and orere point area, particularly those towards the waiti bay end of kawakawa bay coast road, are expected to again be isolated by road and without power or phone for a substantial amount of time.
+waiti bay residents only – consider alternative accommodation.
+auckland civil defence strongly recommends that residents in the waiti bay area look at alternative accommodation for the next few days and potentially for longer.
+should you choose to stay, you may be isolated for some time while power, phone and access is restored. make sure you are prepared.
+general advice
+•	never attempt to drive over slips and treat power lines as live at all times.
+•	if there is an immediate risk to life or property contact the emergency services on 111.
+•	check on neighbours and family, especially if they are in at risk areas or might be affected by flooding or slips.
+•	move away from flooded areas and stay out of floodwaters.
+•	never try to walk, swim, or drive through floodwaters.
+•	if you get stuck in a flood, get out of your car and move to higher ground immediately, taking great care in the floodwaters.
+•	if driving at night, drive slowly, especially through flood-prone areas as you may encounter flooding at short notice.
+
+insurance: once the storm is over or it is safe to return home, contact your insurance company. if possible, take photos of damage.
+take good care of yourself: recovering from a major storm is a big job. it is tough on both your body and your spirit. learn how to recognise and care for anxiety, stress and fatigue.
+if you can’t live in your house due to flooding, slips, lack of access or extreme damage to you, try and stay with family or friends. if you can’t, auckland council may be able to assist, contact us on 0800 22 22 00 for further support.
 
 please take care of yourselves and keep an eye on your community.
 
-auckland civil defence and emergency services  
+auckland civil defence and emergency services
 ","{""type"":""Polygon"",""coordinates"":[[[175.09254455566,-36.937269705849],[175.143699646,-36.923822145792],[175.19519805908,-36.925468913259],[175.23571014404,-36.949617415984],[175.19176483154,-36.992133097866],[175.18146514893,-37.020646433888],[175.16361236572,-37.014889795135],[175.15365600586,-36.98390610969],[175.10902404785,-36.971015372689],[175.12241363525,-36.961140139884],[175.09254455566,-36.937269705849]]]}",kawakawa bay,alert,actual,public,geo,immediate,extreme,observed,2017-04-11 23:40:55,2017-04-11 23:40:00,2017-04-11 23:40:00,2017-04-14 06:00:00,2017-04-11 23:35:12,2017-04-11 23:35:12
 180,96,0,NZL,en,general notifications,weather event and tropical cyclone cook update,"[auckland cdem] afternoon aucklander's,
-there is a high risk of extreme rainfall today (wednesday) and tomorrow across the auckland region prior to the arrival of tropical cyclone cook. 
+there is a high risk of extreme rainfall today (wednesday) and tomorrow across the auckland subnational prior to the arrival of tropical cyclone cook.
 
-some residents in parts of auckland – in particular gulf islands, maraetai, beachlands, kawakawa bay, clevedon, waiheke and south auckland are urged to prepare for strong winds in addition to bursts of heavy rain and coastal storm surges over the next two days. 
+some residents in parts of auckland – in particular gulf islands, maraetai, beachlands, kawakawa bay, clevedon, waiheke and south auckland are urged to prepare for strong winds in addition to bursts of heavy rain and coastal storm surges over the next two days.
 
-current forecasts show the cyclone arriving around midday thursday however, keep an eye on updated forecasts throughout the day as this may change. 
+current forecasts show the cyclone arriving around midday thursday however, keep an eye on updated forecasts throughout the day as this may change.
 
-if your property is at risk of flooding or slips, consider ahead of time whether you need to stay with friends or family for the duration of this storm event. if there is an immediate risk to life or property at any time, contact emergency services on 111. 
+if your property is at risk of flooding or slips, consider ahead of time whether you need to stay with friends or family for the duration of this storm event. if there is an immediate risk to life or property at any time, contact emergency services on 111.
 some communities may be isolated due to the impacts of this weather event and the following tropical cyclone cook.
 
 if you must travel:
-• consider postponing non-essential travel 
+• consider postponing non-essential travel
 • always drive to the weather conditions and never drive through floodwaters.
 • if you get stuck in a flood, get out of your car and move to higher ground immediately, taking great care in the floodwaters.
 • if driving at night, drive slowly, especially through flood-prone areas as you may encounter flooding at short notice.
 • if your property or area may be affected by slips or power outages, prepare for the possibility that your road access may be cut off and ensure you have food and provisions on hand in case of isolation.
-• never attempt to drive over slips and treat power lines as live at all times. 
+• never attempt to drive over slips and treat power lines as live at all times.
 • report blocked drains, flooding and trees down on public land to the council on 09 301 0101.
 
 check on neighbours and family, especially if they are in at risk areas or might be affected by flooding or slips.
@@ -1307,7 +1307,7 @@ please take care and keep an eye on your community.
 
 sincerely,
 auckland civil defence and emergency management
-","{""type"":""Polygon"",""coordinates"":[[[174.63317871094,-36.148964635888],[174.11956787109,-36.467680698273],[174.6826171875,-37.398528132729],[175.15228271484,-37.171260176264],[175.24017333984,-36.954281585676],[175.22918701172,-36.670621934401],[174.73205566406,-36.148964635888],[174.63317871094,-36.148964635888]]]}",auckland region,alert,actual,public,geo,immediate,extreme,observed,2017-04-12 03:21:48,2017-04-12 03:21:00,2017-04-12 03:21:00,2017-04-14 06:00:00,2017-04-12 03:16:03,2017-04-12 03:16:03
+","{""type"":""Polygon"",""coordinates"":[[[174.63317871094,-36.148964635888],[174.11956787109,-36.467680698273],[174.6826171875,-37.398528132729],[175.15228271484,-37.171260176264],[175.24017333984,-36.954281585676],[175.22918701172,-36.670621934401],[174.73205566406,-36.148964635888],[174.63317871094,-36.148964635888]]]}",auckland subnational,alert,actual,public,geo,immediate,extreme,observed,2017-04-12 03:21:48,2017-04-12 03:21:00,2017-04-12 03:21:00,2017-04-14 06:00:00,2017-04-12 03:16:03,2017-04-12 03:16:03
 181,165,0,PHL,en,general notifications,"weather advisory#1 as of 11 am, april 13, 2017
 for low-pressure area","[philippines red cross] weather advisory#1 as of 11 am, april 13, 2017
 for low-pressure area
@@ -1321,7 +1321,7 @@ meanwhile, metro manila, central luzon and the rest of visayas and of mindanao w
 kindly monitor and report any untoward incident to prc opcen at 09188076734; landline- (02) 790 2300
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[115.048828125,11.996338401936],[122.3876953125,21.043491216804],[132.4072265625,6.0531612957141],[121.728515625,5.1784820885229],[115.751953125,8.7547947024356],[114.7412109375,12.039320557541],[115.048828125,11.996338401936]]]}","at 10 am today, the previous monitored low-pressure area was estimated based at 900 km east of hinatuan, surigao del sur.",alert,actual,public,geo,immediate,extreme,observed,2017-04-13 03:55:59,2017-04-13 03:00:00,2017-04-13 03:00:00,2017-04-13 09:00:00,2017-04-13 03:50:10,2017-04-13 03:50:10
-182,96,0,NZL,en,general notifications,delay travel ,[waikato cdem] delay travel: consider delaying your journey to and around the coromandel peninsula until the severe weather passes on friday afternoon or saturday. keep an eye on nzta website for any road closures and metservice updates.,"{""type"":""Polygon"",""coordinates"":[[[175.75927734375,-36.288563198362],[174.9462890625,-36.580246601499],[174.60571289062,-37.987504371064],[176.27563476562,-37.387617499784],[175.75927734375,-36.288563198362]]]}",waikato region,alert,actual,public,geo,immediate,extreme,observed,2017-04-13 04:03:57,2017-04-13 04:10:00,2017-04-13 04:10:00,2017-04-14 06:00:00,2017-04-13 03:58:15,2017-04-13 03:58:15
+182,96,0,NZL,en,general notifications,delay travel ,[waikato cdem] delay travel: consider delaying your journey to and around the coromandel peninsula until the severe weather passes on friday afternoon or saturday. keep an eye on nzta website for any road closures and metservice updates.,"{""type"":""Polygon"",""coordinates"":[[[175.75927734375,-36.288563198362],[174.9462890625,-36.580246601499],[174.60571289062,-37.987504371064],[176.27563476562,-37.387617499784],[175.75927734375,-36.288563198362]]]}",waikato subnational,alert,actual,public,geo,immediate,extreme,observed,2017-04-13 04:03:57,2017-04-13 04:10:00,2017-04-13 04:10:00,2017-04-14 06:00:00,2017-04-13 03:58:15,2017-04-13 03:58:15
 183,96,0,NZL,en,general notifications,consider delays,[waikato cdem] consider delays: consider delaying your journey to and around the coromandel peninsula until the severe weather passes by tomorrow or saturday. keep an eye on the nzta website for any road closures and metservice updates.,"{""type"":""Polygon"",""coordinates"":[[[175.341796875,-36.30627216958],[174.67163085938,-38.07404145942],[176.56127929688,-37.037639679771],[175.341796875,-36.30627216958]]]}",waikato,alert,actual,public,geo,immediate,extreme,observed,2017-04-13 04:18:47,2017-04-13 04:30:00,2017-04-13 04:30:00,2017-04-14 11:59:00,2017-04-13 04:13:04,2017-04-13 04:13:04
 184,96,0,NZL,en,general notifications,bay of plenty civil defence advise self evacuations in the following low lying coastal areas,"[emergency management bop] civil defence is urging people to self-evacuate the following low lying coastal areas due to storm surge risk.
 
@@ -1332,13 +1332,13 @@ information for those evacuating is available on the western bay district counci
 tauranga city:
 inner harbour pilot bay, harbour drive, strange grove, beach road
 information for those evacuating is available on the tauranga city council facebook page and council website.","{""type"":""Polygon"",""coordinates"":[[[175.9391784668,-37.370157184058],[175.86364746094,-37.458508220713],[175.85952758789,-37.608792036044],[175.97213745117,-37.750086547955],[175.94192504883,-37.86509663749],[176.03256225586,-37.896530447543],[176.1506652832,-37.90086509257],[176.63543701172,-37.849916893515],[176.47201538086,-37.730538745741],[176.46102905273,-37.613143571375],[176.40197753906,-37.592471511019],[175.9391784668,-37.370157184058]]]}",western bay of plenty and tauranga city areas,alert,actual,public,geo,immediate,extreme,likely,2017-04-13 04:39:51,2017-04-13 12:00:00,2017-04-13 04:40:00,2017-04-14 12:00:00,2017-04-13 04:34:09,2017-04-13 04:34:09
-185,96,0,NZL,en,general notifications,wind,"[waikato cdem] wind update: coromandel peninsula civil defence has received a new revised forecast which indicates the predicted high winds may not arrive. however, there will still be significant rain fall. those who have already self evacuated are asked to please remain where they are until further advice. those who are currently safe are advised to remain where they are and keep up to date via tcdc facebook page. this includes residents in moanataiari, thames. 
+185,96,0,NZL,en,general notifications,wind,"[waikato cdem] wind update: coromandel peninsula civil defence has received a new revised forecast which indicates the predicted high winds may not arrive. however, there will still be significant rain fall. those who have already self evacuated are asked to please remain where they are until further advice. those who are currently safe are advised to remain where they are and keep up to date via tcdc facebook page. this includes residents in moanataiari, thames.
 ","{""type"":""Polygon"",""coordinates"":[[[175.14404296875,-36.465471886798],[175.517578125,-37.483576550427],[176.24267578125,-37.142803443717],[175.78125,-36.288563198362],[175.14404296875,-36.465471886798]]]}",coromandel,alert,actual,public,geo,immediate,extreme,observed,2017-04-13 04:49:06,2017-04-13 05:00:00,2017-04-13 05:00:00,2017-04-14 00:00:00,2017-04-13 04:43:22,2017-04-13 04:43:22
 186,165,0,PHL,en,general notifications,"weather advisory # 2 as of 11 am, april 14, 2017","[philippines red cross] weather advisory # 2 as of 11 am, april 14, 2017
 
 at 10:00 am today, the low-pressure area (lpa) was at 615 km east of surigao city, surigao del norte.
 
-this weather disturbance is expected to bring moderate to occasionally heavy rains and thunderstorms over the regions of eastern visayas and caraga. meanwhile, bicol region and the rest of visayas and of mindanao will have light to moderate rains and thunderstorms.
+this weather disturbance is expected to bring moderate to occasionally heavy rains and thunderstorms over the subnationals of eastern visayas and caraga. meanwhile, bicol subnational and the rest of visayas and of mindanao will have light to moderate rains and thunderstorms.
 
 this lpa will likely to develop into a tropical depression.
 
@@ -1346,9 +1346,9 @@ kindly monitor and report any untoward incident to prc opcen at 09188076734/ 095
 
 operations center","{""type"":""Polygon"",""coordinates"":[[[117.333984375,16.594081412718],[122.6513671875,21.861498734373],[130.5615234375,6.2279339302687],[120.4541015625,5.0033943450221],[113.466796875,9.8822754934299],[117.333984375,16.594081412718]]]}","at 10:00 am today, the low-pressure area (lpa) was at 615 km east of surigao city, surigao del norte.",alert,actual,public,geo,immediate,extreme,observed,2017-04-14 03:10:44,2017-04-14 03:00:00,2017-04-14 03:00:00,2017-04-14 09:00:00,2017-04-14 03:04:59,2017-04-14 03:04:59
 187,165,0,PHL,en,general notifications,"severe weather bulletin #1 as of 5:00 pm, april 14, 2017
-tropical depression “crising” 
+tropical depression “crising”
 ","[philippines red cross] severe weather bulletin #1 as of 5:00 pm, april 14, 2017
-tropical depression “crising” 
+tropical depression “crising”
 
 the low-pressure area (lpa) east of mindanao has developed into a tropical depression and was named ""crising"".
 
@@ -1365,7 +1365,7 @@ movement: west northwest at 22 kph.
 tropical cyclone warning signal:
 tcws#1- northern samar, eastern samar, samar, and the northern portion of leyte.
 
-positions: 
+positions:
 24 hour (tomorrow afternoon): 45 km north of borongan city, eastern samar.
 
 48 hour (sunday afternoon): in the vicinity of victoria, oriental mindoro.
@@ -1399,7 +1399,7 @@ strength: max sustained winds of 45 kph near the center and gustiness of up to 5
 movement: west northwest at 22 kph.
 
 tropical cyclone warning signal:
-tcws#1- 
+tcws#1-
 visayas: northern samar, eastern samar, samar, and the northern portion of leyte.
 luzon:  sorsogon, albay, and masbate including ticao island.
 
@@ -1419,11 +1419,11 @@ expected to make landfall over samar island tomorrow afternoon.
 
 location of eye/center: at 10:00 pm today, the center of tropical depression ""crising"" was at 310 km east of guiuan, eastern samar.
 
-strength: maximum sustained winds of 45 kph near the center and gustiness of up to 55 kph. 
+strength: maximum sustained winds of 45 kph near the center and gustiness of up to 55 kph.
 
 forecast to move wnw at 20 kph
 
-forecast positions:	
+forecast positions:
 24 hour ( tomorrow evening): 40 km west southwest of catarman, northern samar
 48 hour (sunday evening): 115 km north of coron, palawan
 72 hour (monday evening): 285 km west southwest of iba, zambales
@@ -1453,7 +1453,7 @@ strength: maximum sustained winds of 45 kph near the center and gustiness of up 
 
 forecast to move west northwest at 22 kph
 
-forecast positions:	
+forecast positions:
 24 hour( tonight): in the vicinity of mobo, masbate
 48 hour(monday morning):150 km northwest of coron, palawan
 72 hour(tuesday morning): 315 km west southwest of iba, zambales
@@ -1483,7 +1483,7 @@ strength: maximum sustained winds of 55 kph near the center and gustiness of up 
 
 forecast to move west northwest at 22 kph
 
-forecast positions:	
+forecast positions:
 24 hour ( tomorrow morning): 70 km west of masbate city, masbate
 48 hour (monday morning):200 km northwest of coron, palawan
 72 hour (tuesday morning): 310 km west southwest of iba, zambales
@@ -1512,9 +1512,9 @@ location: at 10 am, the center of td crising was at 155 km east of guiuan, easte
 
 strength: max winds of up to 45 kph near the center and gustiness of up to 55 kph.
 
-forecast to move west northwest at 20 kph 
+forecast to move west northwest at 20 kph
 
-forecast positions: 
+forecast positions:
 24 hrs ( tomorrow morning): 40 km northwest of roxas city, capiz
 48 hrs (monday morning):210 km northwest of coron, palawan
 72 hrs (tuesday morning): 290 km west of iba, zambales
@@ -1525,7 +1525,7 @@ sorsogon, burias island, romblon, masbate including ticao island, aklan, antique
 
 residents in areas under tropical cyclone warning signal (tcws) 1 are alerted against possible flashfloods and landslides.
 
-please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.21118164062,9.5682510190084],[125.51879882812,9.9688506085461],[126.09008789062,11.393879232967],[125.14526367188,13.025965926334],[124.20043945312,14.445319477691],[122.13500976562,14.562317701915],[120.0146484375,13.378931658432],[119.10278320312,11.340025077569],[120.95947265625,9.0695512942332],[124.12353515625,8.657056998509],[125.21118164062,9.5682510190084]]]}",visayas region and part of bicol,alert,actual,public,geo,immediate,moderate,observed,2017-04-15 04:11:02,2017-04-15 03:00:00,2017-04-15 03:00:00,2017-04-15 08:00:00,2017-04-15 04:05:18,2017-04-15 04:05:18
+please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.21118164062,9.5682510190084],[125.51879882812,9.9688506085461],[126.09008789062,11.393879232967],[125.14526367188,13.025965926334],[124.20043945312,14.445319477691],[122.13500976562,14.562317701915],[120.0146484375,13.378931658432],[119.10278320312,11.340025077569],[120.95947265625,9.0695512942332],[124.12353515625,8.657056998509],[125.21118164062,9.5682510190084]]]}",visayas subnational and part of bicol,alert,actual,public,geo,immediate,moderate,observed,2017-04-15 04:11:02,2017-04-15 03:00:00,2017-04-15 03:00:00,2017-04-15 08:00:00,2017-04-15 04:05:18,2017-04-15 04:05:18
 193,165,0,PHL,en,general notifications,tropical cyclone warning for tropical depression "crising","[philippines red cross] severe weather bulletin #8
 issued at 2 pm, 15 april 2017
 
@@ -1539,9 +1539,9 @@ location: at 1 pm, the center of td crising was at 130 km east of guiuan, easter
 
 strength: max winds of up to 45 kph near the center and gustiness of up to 55 kph.
 
-forecast to move west northwest at 20 kph 
+forecast to move west northwest at 20 kph
 
-forecast positions: 
+forecast positions:
 24 hrs ( tomorrow morning): 45 km northwest of roxas city, capiz
 48 hrs (monday morning):305 km northwest of coron, palawan
 72 hrs (tuesday morning): 330 km west of iba, zambales
@@ -1559,7 +1559,7 @@ please report your situation or any untoward incident to prc opcen at 0956148123
 issued at: 2:24 pm, 15 april 2017
 
 orange warning: leyte; southern leyte
-flooding is threatening in low-lying areas and landslides in mountainous areas 
+flooding is threatening in low-lying areas and landslides in mountainous areas
 
 yellow warning: southern portions of eastern samar & samar
 flooding and landslide are possible in some areas.
@@ -1576,9 +1576,9 @@ location: at 4pm, center of td crising was at 50 km east southeast of borongan c
 
 strength: max winds of up to 45 kph near the center and gustiness of up to 62 kph.
 
-forecast to move west northwest at 17 kph 
+forecast to move west northwest at 17 kph
 
-forecast positions: 
+forecast positions:
 24 hour( tomorrow afternoon): 15 km n neof roxas city, capiz
 
 tcwsl #1 (30-60kph expected in 36 hrs)
@@ -1610,7 +1610,7 @@ hyperlink www.nrc.govt.tsunami","{""type"":""Polygon"",""coordinates"":[[[166.13
 hyperlink is www.nrc.govt.nz/tsunami","{""type"":""Polygon"",""coordinates"":[[[166.00341796875,-50.483725935193],[165.86608886719,-50.609388753994],[165.95123291016,-50.675575820586],[165.76995849609,-50.779891974108],[165.86334228516,-50.92035050944],[166.12426757812,-50.993014409795],[166.34399414062,-50.887441411132],[166.28356933594,-50.705155647357],[166.45660400391,-50.467994531476],[166.19842529297,-50.440014664018],[166.00341796875,-50.483725935193]]]}",auckland island,alert,test,public,geo,immediate,extreme,observed,2017-04-19 01:48:40,2017-04-19 01:50:00,2017-04-19 01:50:00,2017-04-21 05:00:00,2017-04-19 01:42:49,2017-04-19 01:42:49
 203,96,0,NZL,en,general notifications,+++northland test for integration into website+++,"[northland civil defence] +++northland test #3 for integration into website
 download the free hazard app to receive alerts to your smartphone - find out more at http://www.nrc.govt.nz","{""type"":""Polygon"",""coordinates"":[[[166.34399414062,-50.433017111357],[166.00067138672,-50.508186602591],[165.88806152344,-50.595442754648],[165.97320556641,-50.692977977465],[165.81115722656,-50.779891974108],[165.89904785156,-50.930738023718],[166.20666503906,-50.948045393551],[166.35223388672,-50.84063582806],[166.26434326172,-50.684277705771],[166.40716552734,-50.51342652634],[166.34399414062,-50.433017111357]]]}",auckland island,alert,test,public,geo,immediate,extreme,observed,2017-04-24 00:07:05,2017-04-24 00:10:00,2017-04-24 00:10:00,2017-04-26 00:00:00,2017-04-24 00:01:14,2017-04-24 00:01:14
-204,165,0,PHL,en,general notifications,severe weather bulletin #1 ,"[philippines red cross] severe weather bulletin #1 
+204,165,0,PHL,en,general notifications,severe weather bulletin #1 ,"[philippines red cross] severe weather bulletin #1
 for: tropical storm ""dante"" (muifa)
 issued at 11am, 26 april 2017
 
@@ -1664,7 +1664,7 @@ issued at 11:00 pm, 27 april 2017
 
 location: at 10:00 pm, the center of td ""dante"" was at 1,425 km east of tuguegarao city, cagayan with max winds of up to 55 kph with 65 kph gustiness moving north northeast at 15 kph.
 
-forecast positions: 
+forecast positions:
 24 hour( tomorrow evening): 1,730 km east of aparri, cagayan (outside par)
 
 no tropical cyclone warning signal","{""type"":""Polygon"",""coordinates"":[[[126.474609375,5.7034479821495],[127.3974609375,10.228437266156],[123.75,16.299051014582],[122.431640625,19.766703551717],[119.4873046875,19.394067895397],[118.8720703125,15.538375926292],[118.4326171875,11.824341483849],[115.9716796875,8.537565350804],[118.740234375,7.0572823529716],[120.7177734375,10.531020008465],[121.640625,8.1897423443837],[119.4873046875,5.5722498011139],[120.146484375,3.995780512963],[122.9150390625,6.31529853833],[125.9033203125,4.6530799182741],[126.474609375,5.7034479821495]]]}",pagasa swb,alert,actual,public,geo,immediate,moderate,observed,2017-04-27 16:30:30,2017-04-27 15:00:00,2017-04-27 15:00:00,2017-04-27 20:00:00,2017-04-27 16:26:56,2017-04-27 16:26:56
@@ -1681,7 +1681,7 @@ when: 4:23 am, 29 april 2017
 
 depth: 57 km, tectonic in origin
 
-reported intensities: 
+reported intensities:
 intensity v- general santos city; koronadal city; santa maria, jose abad santos, don marcelino, balot island, davao occidental; polomolok, tupi, south cotabato; alabel, malapatan, glan, sarangani; palimbag, sultan kudarat
 intensity iv- davao city; cotabato city; zamboanga city
 intensity iii- cagayan de oro city
@@ -1692,7 +1692,7 @@ damages and aftershocks are expected
 tsunami is not expected but sea level disturbances are possible. people near coastal areas are advised to stay away from the beach or the coast.
 
 please report your situation or any untoward incident to prc opcen at 09561481234, hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.9033203125,5.069057826784],[127.3095703125,7.3188817303668],[126.8701171875,10.055402736564],[125.35400390625,9.903921416775],[124.1455078125,9.2539361568145],[122.2119140625,8.6679180023631],[121.3330078125,7.1663003819032],[119.6630859375,5.2222465132274],[119.8388671875,4.3683204208762],[122.7392578125,6.0968598188879],[124.541015625,5.6815836834211],[125.9033203125,5.069057826784]]]}",earthquake report,alert,actual,public,geo,immediate,moderate,observed,2017-04-28 22:13:58,2017-04-28 22:00:00,2017-04-28 22:00:00,2017-04-29 01:00:00,2017-04-28 22:07:52,2017-04-28 22:07:52
-211,96,0,NZL,en,general notifications,+++northland test only+++,"[northland civil defence] another hazard app test to the website 
+211,96,0,NZL,en,general notifications,+++northland test only+++,"[northland civil defence] another hazard app test to the website
 find out more about getaway kits at http://www.happens.co.nz","{""type"":""Polygon"",""coordinates"":[[[166.32614135742,-50.454006666287],[165.97595214844,-50.5125532461],[165.98007202148,-50.563176800422],[165.91415405273,-50.621588113305],[165.98968505859,-50.676446081714],[165.80703735352,-50.786838126951],[165.91003417969,-50.922081922891],[166.17233276367,-50.965346321638],[166.31927490234,-50.847572953654],[166.25885009766,-50.680797145322],[166.39205932617,-50.561432065041],[166.32614135742,-50.454006666287]]]}",auckland island,alert,test,public,geo,immediate,extreme,observed,2017-05-02 01:44:57,2017-05-02 01:45:00,2017-05-02 01:45:00,2017-05-02 05:00:00,2017-05-02 01:38:51,2017-05-02 01:38:51
 212,96,0,NZL,en,general notifications,+++northland test only+++,"[northland civil defence] 1410 hrs tue 2 may
 northland test #7 for website integration.
@@ -1705,7 +1705,7 @@ www.nrc.govt.nz/evacuatenow","{""type"":""Polygon"",""coordinates"":[[[166.37145
 214,96,0,NZL,en,general notifications,***test***,"[ministry for primary industries] ***test***
 mpi test
 ***test***","{""type"":""Polygon"",""coordinates"":[[[166.02951049805,-50.528269818928],[166.03637695312,-50.683407589861],[165.84274291992,-50.777286900749],[165.87844848633,-50.88657506808],[166.08444213867,-50.949775776224],[166.24099731445,-50.895237773601],[166.2629699707,-50.825891011254],[166.22863769531,-50.652943367257],[166.35772705078,-50.4714908514],[166.02951049805,-50.528269818928]]]}",auckland islands,alert,test,public,geo,immediate,extreme,observed,2017-05-05 01:20:06,2017-05-05 01:30:00,2017-05-05 01:21:00,2017-05-05 05:00:00,2017-05-05 01:14:00,2017-05-05 01:14:00
-215,96,0,NZL,en,general notifications,myrtle rust biosecurity alert,"[ministry for primary industries] biosecurity alert: myrtle rust found in northland. if you think you’ve seen myrtle rust on trees, don’t touch it. take a photo and call mpi on 0800 80 99 66. 
+215,96,0,NZL,en,general notifications,myrtle rust biosecurity alert,"[ministry for primary industries] biosecurity alert: myrtle rust found in northland. if you think you’ve seen myrtle rust on trees, don’t touch it. take a photo and call mpi on 0800 80 99 66.
 more info > mpi.govt.nz/myrtlerust","{""type"":""Polygon"",""coordinates"":[[[172.25463867188,-34.415973384482],[174.62768554688,-37.73596920859],[174.25415039062,-38.831149809349],[173.50708007812,-39.215231309105],[173.671875,-39.622614940943],[174.84741210938,-39.97712009844],[176.7041015625,-40.522150985624],[177.25341796875,-39.707186656827],[178.14331054688,-39.223742741391],[178.7255859375,-37.596824001084],[177.85766601562,-37.370157184058],[177.33032226562,-37.770714738496],[176.37451171875,-37.274052809979],[175.63842773438,-35.99578538642],[173.30932617188,-34.125447565116],[172.25463867188,-34.415973384482]]]}",upper north island,alert,actual,public,geo,immediate,extreme,observed,2017-05-05 04:08:45,2017-05-05 04:10:00,2017-05-05 04:10:00,2017-05-12 05:00:00,2017-05-05 04:02:47,2017-05-05 04:02:47
 217,96,0,NZL,en,General Notifications,***TEST***,"***TEST***
 Line Break Test
@@ -1760,10 +1760,10 @@ Please report your situation or any untoward incident to PRC OPCEN at 0956148123
 ","{""type"":""Polygon"",""coordinates"":[[[125.55725097656,8.9556190644434],[126.26586914062,6.9155205730496],[121.904296875,6.5281876136953],[123.01940917969,8.2386736217562],[125.55725097656,8.9556190644434]]]}",Heavy Rainfall Warning,alert,actual,public,geo,immediate,extreme,observed,2017-05-11 10:08:50,2017-05-11 08:45:00,2017-05-11 08:45:00,2017-05-11 11:45:00,2017-05-11 10:02:32,2017-05-11 10:02:32
 224,165,0,PHL,en,General Notifications,Heavy Rainfall Warning due to ITCZ,"[Philippines Red Cross] Weather System: Intertropical Convergence Zone (ITCZ)
 Issued at: 12:00 PM 12 May 2017
- 
+
 Yellow Warning Level: Surigao del Sur(Hinatuan, Bislig, San Roque, San Antonio)
 
-FLOODING is Possible. 
+FLOODING is Possible.
 Flooding in low-lying areas especially along river channels and LANDSLIDES in mountainous areas.
 
 Meanwhile, light to moderate rains affecting Surigao City, Davao del Sur, Davao Oriental, Camiguin Island and nearby areas which may persist for 1-2 hours.
@@ -1772,7 +1772,7 @@ Please report your situation or any untoward incidents to PRC OPCEN at 095614812
 ","{""type"":""Polygon"",""coordinates"":[[[125.32104492188,9.8498039380006],[125.49682617188,10.660607953625],[126.32080078125,10.239248810981],[126.61743164062,9.2430926451048],[126.79321289062,7.7545373465394],[126.44165039062,6.1405547824503],[126.02416992188,6.0313107071258],[125.49682617188,6.6100440932076],[124.61791992188,8.0374733958411],[124.13452148438,9.1671787329767],[125.32104492188,9.8498039380006]]]}",Heavy Rainfall Warning,alert,actual,public,geo,immediate,moderate,observed,2017-05-12 05:36:42,2017-05-12 04:00:00,2017-05-12 04:00:00,2017-05-12 07:00:00,2017-05-12 05:29:49,2017-05-12 05:29:49
 225,165,0,PHL,en,General Notifications,Heavy Rainfall Warning due to ITCZ,"[Philippines Red Cross] Weather System: Intertropical Convergence Zone (ITCZ)
 Issued at: 2:25 PM 12 May 2017
- 
+
 Yellow Warning Level: Surigao del Sur (Hinatuan, Bislig, Lingig), Agusan Del Sur (Talacogon, Rosario, La Paz, Loreto, Bunawan, Trento, San Francisco), Agusan Del Norte (Sibagat) and nearby areas which may persist for 1-2 hours.
 
 Flooding is possible in low-lying areas especially along river channels and landslides in mountainous areas.
@@ -1782,7 +1782,7 @@ Kindly report any monitored untoward incident to OpCen.
 Please report your situation or any untoward incident to PRC OPCEN at 09561481234, Hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[124.95849609375,9.5790843358825],[125.5517578125,10.811724143276],[126.62841796875,9.7631975285472],[126.72729492188,8.157118149072],[126.8701171875,7.3951529071372],[125.3759765625,7.3842578283093],[123.8818359375,8.5484297818819],[124.95849609375,9.5790843358825]]]}",Heavy Rain Fall Warning,alert,actual,public,geo,immediate,moderate,observed,2017-05-12 07:08:42,2017-05-12 06:30:00,2017-05-12 06:30:00,2017-05-12 09:00:00,2017-05-12 07:01:55,2017-05-12 07:01:55
 226,165,0,PHL,en,General Notifications,Heavy Rainfall Warning due to ITCZ,"[Philippines Red Cross] Weather System: Intertropical Convergence Zone (ITCZ)
 Issued at: 4:15 PM 12 May 2017
- 
+
 Yellow Warning Level: Surigao del Sur, Agusan Del Sur, Agusan Del Norte Bukidnon, Misamis Oriental, Lanao del Norte, Lanao Del Sur, Davao City, Davao Del Norte and nearby areas which may persist for 1-2 hours.
 
 Flooding is possible in low-lying areas especially along river channels and landslides in mountainous areas.
@@ -1794,7 +1794,7 @@ Weather System: Low-Pressure Area (LPA)
 ","[Philippines Red Cross] Heavy Rainfall Warning as of 1:15 pm May 13, 2017‬‬‬‬‬‬‬‬‬‬‬‬
 Weather System: Low-Pressure Area (LPA)
 
-Orange Warning Level: Surigao del Sur, Davao Oriental, 
+Orange Warning Level: Surigao del Sur, Davao Oriental,
 
 Yellow Warning Level: Agusan del Norte, Agusan del Sur, Surigao del Norte, Sultan Kudarat, Zamboanga del Norte (Jose Dalman, Sindangan, Salug), Lanao del Norte (Sultan Naga Dimapuro, Sapad), Lanao del Sur(Marogong,Malabang,Balabagan), Zamboanga del Sur (Aurora,Tukuran,Pagadian), Compostela Valley, Davao del Norte.
 
@@ -1831,9 +1831,9 @@ Weather System: Low-Pressure Area (LPA)
 Weather System: Intertropical Convergence Zone (ITCZ)","[Philippines Red Cross] Heavy Rainfall Warning No. 13 as of 4:15 PM May 13, 2017‬‬‬‬‬‬‬‬‬‬‬‬
 Weather System: Intertropical Convergence Zone (ITCZ)
 
-Orange Warning Level: Surigao del Sur, Agusan del Sur. 
+Orange Warning Level: Surigao del Sur, Agusan del Sur.
 
-Yellow Warning Level: Bukidnon, Compostela Valley, Davao Oriental, Sultan Kudarat, Maguindanao, North Cotabato, Sarangani, Zamboanga del Norte (Jose Dalman, Sindangan, Tampilisan), Zamboanga del Sur (Bonifacio,Tabina, Margosa tubig, Pagadian), Zamboanga Sibugay (Payao, Kabasalan, Naga, Ipil, RTLim), Lanao del Norte (SNDimapuro, Sapad), Lanao del Sur(Marogong, Malabang, Balabagan), 
+Yellow Warning Level: Bukidnon, Compostela Valley, Davao Oriental, Sultan Kudarat, Maguindanao, North Cotabato, Sarangani, Zamboanga del Norte (Jose Dalman, Sindangan, Tampilisan), Zamboanga del Sur (Bonifacio,Tabina, Margosa tubig, Pagadian), Zamboanga Sibugay (Payao, Kabasalan, Naga, Ipil, RTLim), Lanao del Norte (SNDimapuro, Sapad), Lanao del Sur(Marogong, Malabang, Balabagan),
 
 Flooding is possible in low-lying area especially along river channels and landslides in mountainous areas.
 ‬‬
@@ -1910,7 +1910,7 @@ When: 10:27 PM, 25 May 2017
 Depth: 88 km, (Manila Trench) Tectonic in origin
 
 Intensity:
-Intensity IV - Quezon City; Pateros; Malolos, Bulacan 
+Intensity IV - Quezon City; Pateros; Malolos, Bulacan
 Intensity III - Tagaytay City; Talisay Batangas; San Jose Del Monte, Bulacan; Pasay City; Makati City; Mandaluyong; Manila City; Paranaque City; Taguig City; San Miguel, Tarlac; Marilao, Bulacan
 Intensity II - Palayan City; Bacoor, Cavite; San Jacinto, Pangasinan
 
@@ -1931,9 +1931,9 @@ Second test for the day for integration through to Twitter: keeping the headline
 Hyperlink:
 www.nrc.govt.nz/evacuatenow","{""type"":""Polygon"",""coordinates"":[[[166.27944954671,-50.467994584827],[166.01303108968,-50.510806690463],[165.89492806233,-50.610260294921],[165.94711312093,-50.664261010643],[165.81115731038,-50.78596996727],[165.89630135335,-50.922081975729],[166.12426766194,-50.97572383957],[166.36734017171,-50.887441464009],[166.23962410726,-50.701676688852],[166.39068611898,-50.563176853666],[166.3577271346,-50.488968626412],[166.27944954671,-50.467994584827]]]}",Auckland Islands,alert,test,public,geo,immediate,extreme,observed,2017-06-07 02:57:54,2017-06-07 02:58:00,2017-06-07 02:58:00,2017-06-07 05:00:00,2017-06-07 02:51:02,2017-06-07 02:51:02
 242,165,0,PHL,en,General Notifications,"Heavy Rainfall Warning #2 as of 3:00 am, June 8, 2017
-Weather System: Intertropical Convergence Zone (ITCZ) 
+Weather System: Intertropical Convergence Zone (ITCZ)
 ","[Philippines Red Cross] Heavy Rainfall Warning #2 as of 3:00 am, June 8, 2017
-Weather System: Intertropical Convergence Zone (ITCZ) 
+Weather System: Intertropical Convergence Zone (ITCZ)
 
 Yellow Warning Level: Surigao Del Sur, Agusan Del Sur, Bukidnon
 
@@ -1947,9 +1947,9 @@ OPERATIONS CENTER
 ","{""type"":""Polygon"",""coordinates"":[[[118.9599609375,8.3202122895229],[127.8369140625,11.049038346537],[126.2548828125,4.3464112753332],[120.673828125,4.8720477002419],[118.0810546875,7.5367643220841],[118.9599609375,8.3202122895229]]]}","Heavy Rainfall Warning #2 as of 3:00 am, June 8, 2017
 Weather System: Intertropical Convergence Zone (ITCZ) ",alert,actual,public,geo,immediate,extreme,observed,2017-06-07 19:17:21,2017-06-07 19:00:00,2017-06-07 19:00:00,2017-06-07 21:00:00,2017-06-07 19:09:58,2017-06-07 19:09:58
 243,165,0,PHL,en,General Notifications,"Heavy Rainfall Warning #2 as of 3:00 am, June 8, 2017
-Weather System: Intertropical Convergence Zone (ITCZ) 
+Weather System: Intertropical Convergence Zone (ITCZ)
 ","[Philippines Red Cross] Heavy Rainfall Warning #2 as of 3:00 am, June 8, 2017
-Weather System: Intertropical Convergence Zone (ITCZ) 
+Weather System: Intertropical Convergence Zone (ITCZ)
 
 Yellow Warning Level: Surigao Del Sur, Agusan Del Sur, Bukidnon
 
@@ -1957,7 +1957,7 @@ Flooding is possible in low-lying areas, especially along river channels.
 
 Meanwhile, light to moderate rains affecting portions of Surigao Del Norte, Siargao Island, Dinagat Island, Agusan Del Norte (Butuan City, Remedios T. Romualdez), Tawi-Tawi, Compostela Valley (Monkayo, Compostela), Davao City, Davao Del Norte, (Tagum City), Samal Island, Davao Oriental (Mati City, Gov. Generoso, Boston, Cateel, Baganga), Davao Del Sur (Jose Abad Santos) and nearby areas which may persist for 1-2 hours.
 
-Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02)  
+Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02)
 790 2300
 
 OPERATIONS CENTER
@@ -2019,7 +2019,7 @@ Please report your situation or any untoward incident to PRC OPCEN at 0956148123
 253,96,0,NZL,en,General Notifications,Headline content populates the Twitter feed,"[Northland Civil Defence] 1000 Wed 28 Jun
 Northland test for Hazard app community - integration of Hazard app with website and social media
 Hyperlink demo: www.nrc.govt.nz/evacuatenow","{""type"":""Polygon"",""coordinates"":[[[166.33026123047,-50.461001115992],[165.98419189453,-50.499452103968],[165.85510253906,-50.616360203881],[165.93475341797,-50.698197366046],[165.76721191406,-50.823288501212],[166.01715087891,-50.987827899091],[166.37969970703,-50.90822881118],[166.30554199219,-50.724285597374],[166.46759033203,-50.541362965222],[166.33026123047,-50.461001115992]]]}",Auckland Islands,alert,test,public,geo,immediate,extreme,observed,2017-06-27 21:56:48,2017-06-27 22:00:00,2017-06-27 22:00:00,2017-06-28 05:00:00,2017-06-27 21:49:34,2017-06-27 21:49:34
-254,165,0,PHL,en,Flood Warning,"Heavy Rainfall Warning No. 2 
+254,165,0,PHL,en,Flood Warning,"Heavy Rainfall Warning No. 2
 Weather System: Intertropical Convergence Zone (ITCZ)","[Philippines Red Cross] Yellow Warning Level: Agusan del Norte, Agusan del Sur, Surigao del Norte, Surigao del Sur
 FLOODING is possible in low-lying areas, especially along river channels.
 
@@ -2030,18 +2030,18 @@ Please report your situation or any untoward incident to PRC OPCEN at 0956148123
 
  Text alerts
  Social Media platforms (including Facebook, Twitter and the BOP CDEM Group website)
- Fixed Sirens   
-   Vehicle mounted alerting units 
+ Fixed Sirens  
+   Vehicle mounted alerting units
 
- 
+
 ","{""type"":""Polygon"",""coordinates"":[[[165.44311523438,-51.395984131786],[167.06217035651,-51.453664585397],[166.86551481485,-50.197227420245],[165.15395432711,-50.175068587847],[165.44311523438,-51.395984131786]]]}",Test at Auckland Island,alert,test,public,geo,immediate,extreme,observed,2017-06-29 23:02:34,2017-06-30 23:05:00,2017-06-29 23:05:00,2017-07-02 00:00:00,2017-06-29 22:55:30,2017-06-29 22:55:30
 256,165,0,PHL,en,General Notifications,"PAGASA Weather Advisory #2 as of 11:00 AM, 01 July , 2017","[Philippines Red Cross] Weather Advisory NO .2 for LPA as of 11:00 AM, 01 July 2017
 
-At 10:00 AM today, the LPA was estimated at 925 km ENE of Guiuan, Eastern Samar. The trough of this weather system will bring cloudy skies with light to moderate rains and thunderstorms over Bicol region and the provinces of Isabela, Aurora, Quezon, and Palawan 
+At 10:00 AM today, the LPA was estimated at 925 km ENE of Guiuan, Eastern Samar. The trough of this weather system will bring cloudy skies with light to moderate rains and thunderstorms over Bicol subnational and the provinces of Isabela, Aurora, Quezon, and Palawan
 
 The LPA is expected to develop into a tropical depression within the next 24 to 36 hours.
 
-Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; 
+Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734;
 
 Landline- (02) 790 2300
 
@@ -2076,8 +2076,8 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.025390625,20.87
 Estimated rainfall amount is moderate to occasionally heavy within the 450-km diameter of the Tropical Depression.
 
 “EMONG” is expected to intensify into a Tropical Storm within the next 6 hours.
- 
-Location: At 10:00 AM today, the center of Tropical Depression “EMONG” was estimated at 520-km East of Basco, Batanes. 
+
+Location: At 10:00 AM today, the center of Tropical Depression “EMONG” was estimated at 520-km East of Basco, Batanes.
 
 Strength: Max sustained winds of up to 60kph near the center and gustiness of up to 75kph.
 
@@ -2168,7 +2168,7 @@ Strength:	Maximum sustained winds of 90 kph near the center and gustiness of up 
 
 Forecast Movement: Forecast to move North Northwest at 30 kph.
 
-Forecast Positions:	
+Forecast Positions:
 24 Hour( Tomorrow morning): 1,310 km North Northeast of Basco, Batanes (OUTSIDE PAR)
 
 48 Hour(Wednesday morning):1,970 km Northeast of Basco, Batanes (OUTSIDE PAR)
@@ -2200,7 +2200,7 @@ Issued at 2:02 PM, 06 July 2017
 
 Thunderstorms affecting portions of Bukidnon, Misamis Oriental, Dinagat Islands, Siargao Islands, Agusan del Norte (Kitcharo, Jabonga, Cabadbaran City), Agusan del Sur (Sibagat, Bayugan, Talacogon, San Luis, Prosperidad, Bunawan, Loreto, Trento), Surigao del Sur(Tandag, San Agustin, Barobo), Compostela Valley(Laak, Montevista), Davao del Norte(Sto. Tomas, Isidro, New Corella, Kapalong), Davao Occidental (Malita), North Cotabato, South Cotabato, Sultan Kudarat, Maguindanao, Lanao del Sur, Zamboanga del Norte, Zamboanga del Sur, Zamboanga Sibugay, Zamboanga City which may persist for 1 to 2 hours.
 
-All are advised to take precautionary measures against heavy rains, strong winds and lightning. 
+All are advised to take precautionary measures against heavy rains, strong winds and lightning.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -2230,12 +2230,12 @@ Thunderstorm is affecting Metro Manila (Caloocan, Malabon, Navotas, Valenzuela),
 
 Expect thunderstorm over Pampanga, Tarlac, Rizal, Cavite and in other areas of MetroManila, Bataan, Zambales, Bulacan, Laguna, Batangas, Quezon within the next 3 hours.
 
-All are advised to take precautionary measures against heavy rains, strong winds, lightning and possible flash floods. 
+All are advised to take precautionary measures against heavy rains, strong winds, lightning and possible flash floods.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.78918457031,16.146092115962],[119.37744140625,15.501325828253],[121.01440429688,13.491131239571],[123.01940917969,14.774882506516],[120.78918457031,16.146092115962]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-07-12 08:52:00,2017-07-12 08:30:00,2017-07-12 08:30:00,2017-07-12 10:00:00,2017-07-12 08:43:54,2017-07-12 08:43:54
-276,165,0,PHL,en,General Notifications,Thunderstorm Advisory ,"[Philippines Red Cross] Thunderstorm Advisory No. 3 
+276,165,0,PHL,en,General Notifications,Thunderstorm Advisory ,"[Philippines Red Cross] Thunderstorm Advisory No. 3
 Issued at: 3:28 PM 13 July 2017
 
 Thunderstorm is affecting Metro Manila, Cavite, Laguna, Rizal, Bulacan, portion of Tarlac, Nueva Ecija, Pampanga, Zambales which may persist within 3 hours.
@@ -2271,7 +2271,7 @@ Synopsis: At 4am today, the center of Tropical Depression ""Fabian"" was est. at
 
 Meanwhile, a LPA was est. at 720 km East of Hinatuan, Surigao del Sur. SW Monsoon affecting the western section of Luzon and of Visayas.
 
-Forecast: Rains with gusty winds is expected over the provinces of Batanes, Cagayan including Babuyan group of Islands, Apayao and Ilocos Norte. Cloudy skies with light to moderate rains and thunderstorms will be experienced over Metro Manila, Visayas, the regions of MIMAROPA, CALABARZON, Zamboanga Peninsula, Northern Mindanao, Caraga, Davao, the rest of Ilocos and Cagayan Valley and over the provinces of Zambales and Bataan. Partly cloudy to cloudy skies with rain showers or thunderstorms will prevail over the rest of the country.
+Forecast: Rains with gusty winds is expected over the provinces of Batanes, Cagayan including Babuyan group of Islands, Apayao and Ilocos Norte. Cloudy skies with light to moderate rains and thunderstorms will be experienced over Metro Manila, Visayas, the subnationals of MIMAROPA, CALABARZON, Zamboanga Peninsula, Northern Mindanao, Caraga, Davao, the rest of Ilocos and Cagayan Valley and over the provinces of Zambales and Bataan. Partly cloudy to cloudy skies with rain showers or thunderstorms will prevail over the rest of the country.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09561481234; Landline- (02) 790 2300
 
@@ -2282,13 +2282,13 @@ Issued at 11 AM, 22 July 2017
 
 TD ""Fabian"" has maintained its strength as it continues to move in a West Northwest direction. It is expected to exit the Philippine Area of Responsibility (PAR) this evening.
 
-Location: At 10:00 AM today, the center of TD ""FABIAN"" was estimated at 170 km WNW of Basco, Batanes. 
+Location: At 10:00 AM today, the center of TD ""FABIAN"" was estimated at 170 km WNW of Basco, Batanes.
 
 Strength: Max winds of up to 55 kph near the center and gustiness of up to 65 kph.
 
-Movement: Forecast to move WNW at 18 kph. 
+Movement: Forecast to move WNW at 18 kph.
 
-Forecast Positions: 
+Forecast Positions:
 24 Hrs (Tomorrow morning): 615 km WNW of Basco, Batanes (OUTSIDE PAR)
 48 Hrs (Monday morning):1,055 km WNW of Basco, Batanes (OUTSIDE PAR)
 
@@ -2298,7 +2298,7 @@ TROPICAL CYCLONE WARNING SIGNAL
 TCWS #1(30-60 kph Expected in 36 hours).
 Luzon: Batanes and Babuyan Group of Islands.
 
-Meanwhile, at 8:00 AM today, the LPA was estimated at 725 km East of Hinatuan, Surigao del Sur. This LPA will bring cloudy skies with light to moderate rains and thunderstorms over the regions of Eastern Visayas, Northern Mindanao, CARAGA, and Davao.
+Meanwhile, at 8:00 AM today, the LPA was estimated at 725 km East of Hinatuan, Surigao del Sur. This LPA will bring cloudy skies with light to moderate rains and thunderstorms over the subnationals of Eastern Visayas, Northern Mindanao, CARAGA, and Davao.
 
 Everyone is advised to be vigilant and kindly report your situation or any untoward incident to PRC OPCEN at 09561481234, Hotline 143 or (02) 7902300
 ","{""type"":""Polygon"",""coordinates"":[[[126.38671875,5.1784820885229],[128.232421875,8.1897423443837],[125.33203125,14.221788628398],[123.3544921875,19.435514339098],[122.0361328125,22.065278067766],[117.861328125,16.762467717942],[118.5205078125,13.496472765759],[115.927734375,9.3623528220556],[115.927734375,7.8416151852047],[118.212890625,7.1444988496473],[119.970703125,4.3464112753332],[126.38671875,5.1784820885229]]]}","Severe Weather Bulletin for Northern Luzon, Visayas and Mindanao Regions",alert,actual,public,geo,immediate,moderate,observed,2017-07-22 04:45:13,2017-07-22 03:00:00,2017-07-22 03:00:00,2017-07-22 08:00:00,2017-07-22 04:36:00,2017-07-22 04:36:00
@@ -2312,16 +2312,16 @@ All Tropical Cyclone warning signal are now lifted.
 
 Estimated rainfall amount is from moderate to heavy within the 150 km diameter of the Tropical Depression.
 
-Meanwhile, at 5PM today, the Low Pressure Area (LPA) was estimated at 480 km ENE of Hinatuan, Surigao del Sur. This LPA will bring cloudy skies with light to moderate rains and thunderstorms over the regions of Eastern Visayas, Northern Mindanao, CARAGA, and Davao.
+Meanwhile, at 5PM today, the Low Pressure Area (LPA) was estimated at 480 km ENE of Hinatuan, Surigao del Sur. This LPA will bring cloudy skies with light to moderate rains and thunderstorms over the subnationals of Eastern Visayas, Northern Mindanao, CARAGA, and Davao.
 
 Everyone is advised to be vigilant and kindly report your situation or any untoward incident to PRC OPCEN at 09561481234, Hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[125.9912109375,4.9377242743025],[127.79296875,7.3188817303668],[126.03515625,12.597454504832],[123.8818359375,15.220589019578],[122.62939453125,15.496032414239],[123.24462890625,18.375379094032],[122.4755859375,20.179723502765],[119.6630859375,20.035289711352],[118.49853515625,14.987239525774],[116.34521484375,9.4924081537655],[116.12548828125,7.4060477170763],[119.00390625,7.5585466060932],[120.69580078125,10.444597722835],[121.81640625,8.7982254590164],[119.70703125,5.9876068916583],[119.53125,3.8423316311549],[123.50830078125,6.7082539686715],[125.79345703125,5.0471707369197],[125.9912109375,4.9377242743025]]]}",Final Severe Weather Bulletin for Visayas and Mindanao,alert,actual,public,geo,immediate,moderate,observed,2017-07-22 11:43:24,2017-07-22 09:00:00,2017-07-22 09:00:00,2017-07-22 14:00:00,2017-07-22 11:34:12,2017-07-22 11:34:12
 282,165,0,PHL,en,General Notifications,"PAGASA Weather Advisory #2 as of 10:00 AM, July 24, 2017
 For: Low Pressure Area (LPA)","[Philippines Red Cross] PAGASA Weather Advisory #2 as of 10:00 AM, July 24, 2017
 For: Low Pressure Area (LPA)
 
-At 9:00 AM today, The Low Pressure Area (LPA) was estimated at 425 km East of Guiuan, Eastern Samar. 
+At 9:00 AM today, The Low Pressure Area (LPA) was estimated at 425 km East of Guiuan, Eastern Samar.
 
-This weather system will bring cloudy skies with light to moderate rains and thunderstorms over the regions of Eastern Visayas and CARAGA. 
+This weather system will bring cloudy skies with light to moderate rains and thunderstorms over the subnationals of Eastern Visayas and CARAGA.
 
 Furthermore, the LPA is likely to develop into a Tropical Depression within the next 24 hour to 48 hours.
 
@@ -2333,9 +2333,9 @@ For: Low Pressure Area (LPA)",alert,actual,public,geo,immediate,extreme,observed
 
 At 9:00 AM today, The Low Pressure Area (LPA) was at 630 km. East of Virac, Catanduanes.
 
-This weather system will bring cloudy skies with light to moderate rains and thunderstorms over the regions of Bicol and Eastern Visayas.
+This weather system will bring cloudy skies with light to moderate rains and thunderstorms over the subnationals of Bicol and Eastern Visayas.
 
-Furthermore, the LPA is likely to develop into a Tropical Depression within the next 24-48 hours. 
+Furthermore, the LPA is likely to develop into a Tropical Depression within the next 24-48 hours.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -2381,7 +2381,7 @@ Strength: Maximum winds of up to 55 kph near the center and gustiness of up to 6
 
 Forecast to move North Northwest at 15 kph.
 
-Forecast Positions 
+Forecast Positions
 24 Hour( Tomorrow evening): 540 km North East of Virac, Catanduanes
 48 Hour(Thursday evening):610 km East of Basco, Batanes
 72 Hour(Friday evening): 900 km Eeast Northeast of Basco, Batanes
@@ -2395,11 +2395,11 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.0693359375,21.493963563064],[132.4951171875,4.8720477002419],[118.916015625,4.5654735507103],[114.78515625,8.4071681636011],[121.0693359375,21.493963563064]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-07-25 15:37:50,2017-07-25 15:00:00,2017-07-25 15:00:00,2017-07-25 18:00:00,2017-07-25 15:28:59,2017-07-25 15:28:59
 286,165,0,PHL,en,General Notifications,PAGASA Weather Forecast ,"[Philippines Red Cross] PAGASA Weather Forecast issued at 4AM, 26 July 2017
 
-SYNOPSIS: At 3:00 AM today, the center of Tropical Depression ""Gorio"" was at 440 km Northeast of Borongan City, Eastern Samar with maximum sustained winds of 60 km/h near the center and gustiness of up to 75 km/h. It is forecast to move North Northwest at 15 km/h. 
+SYNOPSIS: At 3:00 AM today, the center of Tropical Depression ""Gorio"" was at 440 km Northeast of Borongan City, Eastern Samar with maximum sustained winds of 60 km/h near the center and gustiness of up to 75 km/h. It is forecast to move North Northwest at 15 km/h.
 
-Southwest Monsoon affecting the western section of Luzon and Visayas. 
+Southwest Monsoon affecting the western section of Luzon and Visayas.
 
-FORECAST: Cloudy skies with light to moderate rains and thunderstorms will be experienced over Metro Manila, Visayas, the regions of Ilocos, CALABARZON, MIMAROPA, Bicol, Caraga, and the provinces of Zambales, Bataan and Aurora. Partly cloudy to cloudy skies with isolated rainshowers or thunderstorms will prevail over the rest of the country.
+FORECAST: Cloudy skies with light to moderate rains and thunderstorms will be experienced over Metro Manila, Visayas, the subnationals of Ilocos, CALABARZON, MIMAROPA, Bicol, Caraga, and the provinces of Zambales, Bataan and Aurora. Partly cloudy to cloudy skies with isolated rainshowers or thunderstorms will prevail over the rest of the country.
 
 Hight Tide Today: 11:48 am (1:39 meter)
 Low Tide Today: 7:44 pm (0.08 meter)
@@ -2439,10 +2439,10 @@ Weather System: Southwest Monsoon
 ",alert,actual,public,geo,immediate,extreme,observed,2017-07-26 02:11:49,2017-07-26 03:00:00,2017-07-26 00:00:00,2017-07-26 03:00:00,2017-07-26 02:03:08,2017-07-26 02:03:08
 289,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #3 as of 11:00 AM, July 26, 2017
 
-""GORIO"" has intensified into a Tropical Storm and slightly slowed down as it moves North Northwestward. 
+""GORIO"" has intensified into a Tropical Storm and slightly slowed down as it moves North Northwestward.
 ","[Philippines Red Cross] Severe Weather Bulletin #3 as of 11:00 AM, July 26, 2017
 
-""GORIO"" has intensified into a Tropical Storm and slightly slowed down as it moves North Northwestward. 
+""GORIO"" has intensified into a Tropical Storm and slightly slowed down as it moves North Northwestward.
 
 Estimated rainfall amount is from moderate to heavy within the 400 km diameter of the Tropical Storm.
 
@@ -2450,7 +2450,7 @@ This weather system will enhance Southwest Monsoon which will bring moderate to 
 
 Location: At 10:00 am today, the center of Tropical Storm ""GORIO"" was at 595 km East of Casiguran, Aurora.
 
-Strength: Max sustained winds of 65 kph near the center and gustiness of up to 80 kph. 
+Strength: Max sustained winds of 65 kph near the center and gustiness of up to 80 kph.
 
 Movement: North Northwest at 13 kph
 
@@ -2461,7 +2461,7 @@ Positions:
 
 72 Hour (Saturday morning): 275 km Northeast of Basco, Batanes.
 
-96 Hour (Sunday morning): 475 km North Northeast of Basco, Batanes. 
+96 Hour (Sunday morning): 475 km North Northeast of Basco, Batanes.
 
 120 Hour (Monday morning): 700 km Northeast of Basco, Batanes (OUTSIDE PAR).
 
@@ -2472,7 +2472,7 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 OPERATIONS CENTER
 ","{""type"":""Polygon"",""coordinates"":[[[117.421875,14.136575651478],[121.81640625,21.861498734373],[131.044921875,5.441022303718],[119.619140625,5.441022303718],[114.169921875,9.8389793755793],[117.421875,14.136575651478]]]}","Severe Weather Bulletin #3 as of 11:00 AM, July 26, 2017
 
-""GORIO"" has intensified into a Tropical Storm and slightly slowed down as it moves North Northwestward. 
+""GORIO"" has intensified into a Tropical Storm and slightly slowed down as it moves North Northwestward.
 ",alert,actual,public,geo,immediate,extreme,observed,2017-07-26 03:46:46,2017-07-26 03:00:00,2017-07-26 03:00:00,2017-07-26 06:00:00,2017-07-26 03:38:16,2017-07-26 03:38:16
 290,165,0,PHL,en,General Notifications,Heavy Rainfall Warning,"[Philippines Red Cross] Heavy Rainfall Warning No. 7 NCR
 Weather System: Southwest Monsoon
@@ -2521,7 +2521,7 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.9814453125,21.4
 292,165,0,PHL,en,General Notifications,Rainfall Advisory ,"[Philippines Red Cross] Rainfall Advisory NCR
 Issued at 3:48 AM,  27 July 2017
 
-Light to moderate with occasional heavy rains affecting Metro Manila, Zambales, Tarlac, Bataan and portions of Pampanga, Bulacan which may persist for 2 hours. 
+Light to moderate with occasional heavy rains affecting Metro Manila, Zambales, Tarlac, Bataan and portions of Pampanga, Bulacan which may persist for 2 hours.
 
 Expect light to moderate rains over Rizal, Cavite, Quezon, Laguna within the next 3 hours.
 
@@ -2535,9 +2535,9 @@ SYNOPSIS: At 3:00 AM today, the center of Tropical Storm ""Gorio"" (Nesat) was a
 
 Southwest Monsoon affecting Luzon and Western Visayas.
 
-FORECAST: Monsoon rains which may trigger flashfloods and landslides are expected over Metro Manila and the regions of Ilocos, Cordillera, Central Luzon CALABARZON and the provinces of Mindoro and Palawan. 
+FORECAST: Monsoon rains which may trigger flashfloods and landslides are expected over Metro Manila and the subnationals of Ilocos, Cordillera, Central Luzon CALABARZON and the provinces of Mindoro and Palawan.
 
-Cloudy skies with light to moderate rains and thunderstorms will be experienced over Visayas and the regions of Cagayan Valley, Bicol and the provinces of Marinduque and Romblon. 
+Cloudy skies with light to moderate rains and thunderstorms will be experienced over Visayas and the subnationals of Cagayan Valley, Bicol and the provinces of Marinduque and Romblon.
 Partly cloudy to cloudy skies with isolated rainshowers or thunderstorm will prevail over Mindanao.
 
 Hight Tide Today: 12:36 PM (1.28 m)
@@ -2600,14 +2600,14 @@ Storm Warning Signal #1 (30-60 kph, expected in 36 hrs) Batanes
 
 Wave Height: (Open Sea) 1.25-4.0 meters
 
-Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- 
+Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline-
 
 (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.4541015625,19.725342248058],[118.2568359375,13.838079936422],[116.1474609375,7.6674414827261],[120.5859375,7.2752923363722],[122.783203125,5.1784820885229],[128.1884765625,4.5216663426148],[128.5400390625,11.049038346537],[124.4091796875,18.771115062337],[120.4541015625,19.725342248058]]]}","Luzon, Visayas and Mindanao",alert,actual,public,geo,immediate,moderate,observed,2017-07-27 09:30:36,2017-07-27 08:00:00,2017-07-27 08:00:00,2017-07-27 13:00:00,2017-07-27 09:21:54,2017-07-27 09:21:54
-297,96,0,NZL,en,General Notifications,"BOIL WATER NOTICE FOR HOOK WAITUNA RURAL WATER SCHEME 
+297,96,0,NZL,en,General Notifications,"BOIL WATER NOTICE FOR HOOK WAITUNA RURAL WATER SCHEME
 28 July 2017
-","[Waimate CDEM] BOIL WATER NOTICE FOR HOOK WAITUNA RURAL WATER SCHEME 
+","[Waimate CDEM] BOIL WATER NOTICE FOR HOOK WAITUNA RURAL WATER SCHEME
 
 28 July 2017
 
@@ -2619,7 +2619,7 @@ Please also inform all staff and tenants on your property of this reminder.
 
 For up to date information please see the Waimate District Council website: www.waimatedc.govt.nz . For questions, please phone 03-689-0000.
 
- 
+
 
 Paul Roberts
 Water & Waste Manager
@@ -2649,7 +2649,7 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.6298828125,19.808054128089],[118.388671875,15.284185114076],[119.4873046875,12.726084296948],[116.015625,7.8851472834243],[118.037109375,7.4496242601978],[121.6845703125,10.314919285813],[119.8828125,5.8783321096743],[123.1787109375,4.5654735507103],[126.6943359375,5.0033943450221],[129.7265625,6.4463177494577],[125.9033203125,13.667338259655],[123.5302734375,19.103648251664],[120.6298828125,19.808054128089]]]}",Luzon and Visayas,alert,actual,public,geo,immediate,moderate,observed,2017-07-28 04:32:43,2017-07-28 02:00:00,2017-07-28 02:00:00,2017-07-28 07:00:00,2017-07-28 04:24:19,2017-07-28 04:24:19
 299,165,0,PHL,en,Tropical Storm Warning,"SEVERE WEATHER BULLETIN #10
-For: Severe Tropical Storm Gorio 
+For: Severe Tropical Storm Gorio
 Issued at 5PM, July 28, 2017","[Philippines Red Cross] Gorio has maintained its strength as it continues to move Northwestward direction.
 
 Est. rainfall amount is from moderate to heavy within the 600 km diameter of the Severe Tropical Storm. Meanwhile, Tropical Depression outside PAR was estimated at 600 km West of Calayan, Cagayan.
@@ -2666,7 +2666,7 @@ Forecast Positions:
 • 24 Hour (Tomorrow afternoon): 220 km North Northeast of Basco, Batanes
 • 48 Hour (Sun, afternoon): 450 km North North Northwest of Basco, Batanes (outside PAR)
 
-Storm Warning Signal 
+Storm Warning Signal
 #2 (61-120 kph, expected in 24 hrs) Batanes Group of Islands
 #1 (30-60 kph, expected in 36 hrs) Babuyan group of Islands
 
@@ -2707,7 +2707,7 @@ The Tropical Depression located over the West Philippine Sea was estimated at 56
 
 These weather systems will continue to enhance the Southwest Monsoon which will bring moderate to occasionally heavy rains over the western section of Northern and Central Luzon while light to moderate rains over Metro Manila and the rest of Luzon.
 
-Location: At 4:00 AM today, the eye of TY ""GORIO"" was at 200 km NE of Basco, Batanes 
+Location: At 4:00 AM today, the eye of TY ""GORIO"" was at 200 km NE of Basco, Batanes
 
 Strength: Max sustained winds of up to 145 kph near the center and gustiness of up to 180 kph.
 
@@ -2772,7 +2772,7 @@ The Tropical Storm with International Name ""HAITANG has maintained its strength
 
 Estimated rainfall amount is from moderate to heavy within the 500 km diameter of the Tropical Storm.
 
-This weather system will continue to enhance the Southwest Monsoon which will bring moderate to occasionally heavy rains over the western section of Northern and Central Luzon. 
+This weather system will continue to enhance the Southwest Monsoon which will bring moderate to occasionally heavy rains over the western section of Northern and Central Luzon.
 
 HAITANG is expected to make landfall over Southern Taiwan this evening.
 
@@ -2804,7 +2804,7 @@ The Tropical Storm with International Name ""HAITANG"" has entered the Philippin
 
 Estimated rainfall amount is from moderate to heavy within the 500 km diameter of the Tropical Storm.
 
-This weather system will continue to enhance the Southwest Monsoon which will bring moderate to occasionally heavy rains over the western section of Northern and Central Luzon. 
+This weather system will continue to enhance the Southwest Monsoon which will bring moderate to occasionally heavy rains over the western section of Northern and Central Luzon.
 
 HUANING is expected to make landfall over Southern Taiwan this evening.
 
@@ -2837,7 +2837,7 @@ Tropical Storm ""HUANING"" has slightly intensified, accelerated, and is now mov
 
 Estimated rainfall amount is from moderate to heavy within the 500 km diameter of the Tropical Storm.
 
-This weather system will continue to enhance the Southwest Monsoon which will bring moderate to occasionally heavy rains over the western section of Northern and Central Luzon. 
+This weather system will continue to enhance the Southwest Monsoon which will bring moderate to occasionally heavy rains over the western section of Northern and Central Luzon.
 
 HUANING is expected to make landfall over Southern Taiwan tonight.
 
@@ -2874,7 +2874,7 @@ Strenght: Maximum sustained winds of up to 85 kph near the center and gustiness 
 
 Forecast Movement: North Northwest at 24 kph
 
-Forecast Positions: 
+Forecast Positions:
 24 hour (Tomorrow evening): 845 km North Northwest of Basco, Batanes (outside PAR)
 
 48 hour (Tuesday evening): 1,320 km North Northwest of Basco, Batanes (outside PAR)
@@ -2889,7 +2889,7 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.76171875,20.920396913972],[133.154296875,4.5216663426148],[119.3994140625,5.6597185545773],[113.466796875,8.3202122895229],[120.76171875,20.920396913972]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-07-30 15:31:33,2017-07-30 15:00:00,2017-07-30 15:00:00,2017-08-30 18:00:00,2017-07-30 15:23:02,2017-07-30 15:23:02
 308,165,0,PHL,en,General Notifications,SEVERE WEATHER BULLETIN,"[Philippines Red Cross] SEVERE WEATHER BULLETIN #5
 FOR: Tropical Storm ""HUANING"" (HAITANG)
-ISSUED AT: 5:00 AM, 31 July 2017 
+ISSUED AT: 5:00 AM, 31 July 2017
 
 Tropical Storm  ""HUANING"" has slightly weakened and is about to exit The Philippine Area of Responsibility (PAR).
 
@@ -2899,7 +2899,7 @@ Strength: Maximum sustained winds of up to 65 kph near the center and gustiness 
 
 Forecast Movement: North Northwest at 24 kph.
 
-Forecast Positions:	
+Forecast Positions:
 24 hour (Tomorrow morning): 1,210 km North Northwest of Basco, Batanes
 36 hour (Tomorrow afternoon): 1,560 km North Northwest of Basco, Batanes
 
@@ -2931,7 +2931,7 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.4541015625,21.28937435586],[133.6376953125,4.7844689665794],[121.025390625,5.0033943450221],[113.9501953125,9.1888700844734],[120.4541015625,21.28937435586]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-07-31 00:07:03,2017-08-31 00:00:00,2017-07-31 00:00:00,2017-08-31 02:00:00,2017-07-30 23:58:04,2017-07-30 23:58:04
 310,96,0,NZL,en,General Notifications,***TEST***,"***TEST***
-NZRC Test 
+NZRC Test
 ***TEST***","{""type"":""Polygon"",""coordinates"":[[[166.04461669922,-50.523904629229],[166.03088378906,-50.6912380522],[165.85510253906,-50.771207831888],[165.86608886719,-50.854509047813],[166.00891113281,-50.930738023718],[166.11053466797,-50.948045393551],[166.26434326172,-50.871844771024],[166.27258300781,-50.816347765191],[166.23138427734,-50.684277705771],[166.34948730469,-50.541362965222],[166.36047363281,-50.457504020421],[166.04461669922,-50.523904629229]]]}",Auckland Island,alert,actual,public,geo,immediate,extreme,observed,2017-08-04 00:35:43,2017-08-04 00:37:00,2017-08-04 00:37:00,2017-08-04 05:00:00,2017-08-04 00:27:44,2017-08-04 00:27:44
 311,96,0,NZL,en,General Notifications,Test from Northland CDEM Group,[Northland Civil Defence] Test message for website and social media feed,"{""type"":""Polygon"",""coordinates"":[[[166.31378173828,-50.470616795657],[166.01989746094,-50.509933308457],[165.90728759766,-50.594570992462],[165.9814453125,-50.6894980624],[165.82489013672,-50.77033932898],[165.91278076172,-50.941123218673],[166.23275756836,-50.957561701112],[166.31652832031,-50.805066868783],[166.24374389648,-50.711243296544],[166.38793945312,-50.568410619004],[166.31378173828,-50.470616795657]]]}",Auckland Island,alert,test,public,geo,immediate,extreme,observed,2017-08-04 02:01:08,2017-08-04 02:02:00,2017-08-04 02:02:00,2017-08-04 04:30:00,2017-08-04 01:53:09,2017-08-04 01:53:09
 312,165,0,PHL,en,General Notifications,EARTHQUAKE,"What: 6.3 Earthquake
@@ -2985,7 +2985,7 @@ Please report your situation or any untoward incident to PRC OPCEN at 0956143123
 Weather System: Inter Tropical Convergence Zone ","Yellow Warning Level: Metro Manila and Bulacan
 FLOODING is possible in low lying areas.
 
-Heavy rains with lightning and strong winds due to thunderstorms are being experienced in Zambales, Tarlac, Nueva Ecija, Bataan, Pampanga, Rizal, Laguna, Cavite, Batangas and Quezon which may persist within 2 hours or more and may affect nearby areas. 
+Heavy rains with lightning and strong winds due to thunderstorms are being experienced in Zambales, Tarlac, Nueva Ecija, Bataan, Pampanga, Rizal, Laguna, Cavite, Batangas and Quezon which may persist within 2 hours or more and may affect nearby areas.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -2994,10 +2994,10 @@ OPERATIONS CENTER
 Weather System: Inter Tropical Convergence Zone ",alert,actual,public,geo,immediate,extreme,observed,2017-08-19 13:29:19,2017-08-19 13:00:00,2017-08-19 13:00:00,2017-08-19 16:00:00,2017-08-19 13:19:50,2017-08-19 13:19:50
 317,165,0,PHL,en,General Notifications,"Heavy Rainfall Warning No. 1A as of 9:30 PM 19 August 2017
 
-Weather System: Inter Tropical Convergence Zone 
+Weather System: Inter Tropical Convergence Zone
 ","Heavy Rainfall Warning No. 1A as of 9:30 PM, 19 August 2017
 
-Weather System: Inter Tropical Convergence Zone 
+Weather System: Inter Tropical Convergence Zone
 
 Red Warning Level: Metro Manila
 FLOODING is expected in flood-prone areas.
@@ -3008,18 +3008,18 @@ FLOODING is THREATENING.
 Yellow Warning Level: Cavite, Pampanga, and Rizal
 FLOODING possible in low lying areas.
 
-Heavy rains with lightning and strong winds due to thunderstorms are being experienced in Zambales, Tarlac, Nueva Ecija, Bataan, Laguna, Batangas and Quezon which may persist within 2 hours or more and may affect nearby areas. 
+Heavy rains with lightning and strong winds due to thunderstorms are being experienced in Zambales, Tarlac, Nueva Ecija, Bataan, Laguna, Batangas and Quezon which may persist within 2 hours or more and may affect nearby areas.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER
 ","{""type"":""Polygon"",""coordinates"":[[[119.1357421875,15.813395760461],[123.51928710938,15.294782590261],[123.23364257812,14.392118083662],[119.80590820312,13.368243250897],[119.1357421875,15.813395760461]]]}","Heavy Rainfall Warning No. 1A as of 9:30 PM 19 August 2017
 
-Weather System: Inter Tropical Convergence Zone 
+Weather System: Inter Tropical Convergence Zone
 ",alert,actual,public,geo,immediate,extreme,observed,2017-08-19 13:56:08,2017-08-19 13:00:00,2017-08-19 13:00:00,2017-08-19 16:00:00,2017-08-19 13:46:36,2017-08-19 13:46:36
 318,165,0,PHL,en,General Notifications,"Heavy Rainfall Warning No. 2 as of 12:30 AM, 20 August 2017
 Weather System: Inter Tropical Convergence Zone ","Heavy Rainfall Warning No. 2 as of 12:30 AM, 20 August 2017
-Weather System: Inter Tropical Convergence Zone 
+Weather System: Inter Tropical Convergence Zone
 
 Red Warning Level: Metro Manila
 FLOODING is expected in flood prone areas.
@@ -3114,13 +3114,13 @@ Movement: West Northwest at 17 kph
 
 Positions:
 24 Hour (Tomorrow morning): 115 km West Northwest of Basco, Batanes.
- 
+
 48 Hour (Wednesday morning):570 km West Northwest of Basco, Batanes (OUTSIDE PAR).
 
 72 Hour (Thursday morning): 1,250 km West Northwest of Laoag City, Ilocos Norte (OUTSIDE PAR)
 
 Tropical Cyclone Warning Signal:
-TCWS#2- Batanes group of Islands 
+TCWS#2- Batanes group of Islands
 TCWS#1- Babuyan group of Islands
 
 Wave Height: (Open Sea) 1.25-4.0 meters
@@ -3150,7 +3150,7 @@ Strength: Max sustained winds of up to 65kph near the center and gustiness of up
 
 Movement: West Northwest at 17kph
 
-Positions: 
+Positions:
 24 hour (Tomorrow morning): 180km West of Basco, Batanes
 48 hour (Wednesday morning): 610km West of Basco, Batanes (OUTSIDE PAR)
 72 hour (Thursday morning): 1,345km West Northwest of Basco, Batanes
@@ -3277,7 +3277,7 @@ Warning Signal
 
 Moderate to occasionally heavy rains are expected within the 400 km diameter of the Tropical Storm.
 
-“ISANG” is expected to be in the vicinity of Batanes this midnight. 
+“ISANG” is expected to be in the vicinity of Batanes this midnight.
 
 This weather system will enhance the SW Monsoon which may bring light to moderate with possible occasionally heavy rains over Visayas and the rest of Luzon particularly over the western section and Cordillera Administrative Region (CAR).
 
@@ -3305,8 +3305,8 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.5966796875,21.28937435586],[118.564453125,15.623036831528],[116.982421875,10.574222078333],[116.19140625,7.7545373465394],[118.65234375,6.6646075621726],[122.0361328125,5.1784820885229],[128.759765625,5.6597185545773],[127.2216796875,10.876464994816],[125.2001953125,16.256867330623],[121.5966796875,21.28937435586]]]}",Luzon and Visayas,alert,actual,public,geo,immediate,moderate,observed,2017-08-21 21:52:47,2017-08-21 21:00:00,2017-08-21 21:00:00,2017-08-21 23:00:00,2017-08-21 21:44:23,2017-08-21 21:44:23
 329,165,0,PHL,en,General Notifications,Severe Weather Bulletin,"Severe Weather Bulletin #13
-For Severe Tropical Storm Isang 
-Issued at: 11:00 AM, 22 August 2017 
+For Severe Tropical Storm Isang
+Issued at: 11:00 AM, 22 August 2017
 
 ""ISANG"" has intensified into a Severe Tropical Storm as it continues to move in a Westward direction.
 
@@ -3318,7 +3318,7 @@ Strength: Max sustained winds of 90 kph near the center and gustiness of up to 1
 
 Movement: Forecast to move West at 23 kph
 
-Forecast Positions:	
+Forecast Positions:
 24 HR (Tomorrow morning): 770 km West Northwest of Laoag City, Ilocos Norte (OUTSIDE PAR)
 
 48 HR (Thursday morning): 1,370 km West Northwest of Laoag City, Ilocos Norte (OUTSIDE PAR)
@@ -3348,7 +3348,7 @@ The Low-Pressure Area (LPA) estimated over East Northeast of Virac, Catanduanes 
 
 Estimated rainfall amount is from moderate to heavy within the 300-km diameter of the Tropical Depression.
 
-Expected to further intensify before making a landfall over Northern Luzon by Friday evening or Saturday early morning. 
+Expected to further intensify before making a landfall over Northern Luzon by Friday evening or Saturday early morning.
 
 A possible raising of Tropical Cyclone Warning Signal (TCWS) #1 over Quirino, Ifugao, Mt. Province, Kalinga and Northern Cagayan tonight.
 
@@ -3413,7 +3413,7 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.5859375,20.673905264673],[133.06640625,5.7471740766514],[120.322265625,3.8642546157214],[114.7412109375,8.885071663469],[120.5859375,20.673905264673]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-08-24 15:47:40,2017-08-24 15:00:00,2017-08-24 15:00:00,2017-08-24 18:00:00,2017-08-24 15:39:11,2017-08-24 15:39:11
 333,165,0,PHL,en,General Notifications,Severe Weather Bulletin,"Severe Weather Bulletin #3
 For: Tropical Depression Jolina
-Issued at 5:00 AM, 25 August 2017 
+Issued at 5:00 AM, 25 August 2017
 
 ""JOLINA"" has intensified into a Tropical Storm and has slighty accelerated as it moves closer towards Northern-Central Luzon area.
 
@@ -3427,7 +3427,7 @@ Strength:	Max sustained winds of 65 kph near the center and gustiness of up to 8
 
 Movement: Forecast to move West Northwest at 19 kph
 
-Forecast Positions:	
+Forecast Positions:
 24 Hour( Tom morning): In the vicinity of Tubo, Abra
 
 48 Hour(Sun morning): 625 km West of Basco, Batanes (OUTSIDE PAR)
@@ -3608,22 +3608,22 @@ Issued at 5 AM, 26 August 2017
 
 TS Jolina has slightly weakened and is now in the vicinity of Ifugao Province.
 
-Estimated rainfall amount is from moderate to heavy within the 
+Estimated rainfall amount is from moderate to heavy within the
 300 km diameter of the Tropical Storm.
 
 Monsoon rains are expected over the Western sections of Central and Southern Luzon. Residents in these areas, especially those under Tropical Cyclone Warning Signals (TCWS) 2 and 1 are alerted against possible flashfloods and landslides.
 
 Expected to exit the landmass of Luzon this morning and at the Northwestern boundary of PAR tonight.
 
-Loc: As of 4 AM,  the center of TS ""JOLINA"" was estimated in the 
-vicinity of Aguinaldo, Ifugao with max wind of 75 kph and 
+Loc: As of 4 AM,  the center of TS ""JOLINA"" was estimated in the
+vicinity of Aguinaldo, Ifugao with max wind of 75 kph and
 gustiness of up to 120 kph moving Northwest at 20 kph.
 
 Forecast Positions:
 24 Hour (Tomorrow morning): 380 km WNW of Laoag City, Ilocos Norte (Outside Par)
-48 Hour (Monday morning): 1,125 km WNW of Laoag City, Ilocos 
+48 Hour (Monday morning): 1,125 km WNW of Laoag City, Ilocos
 Norte (Outside Par)
-72 Hour (Tuesday morning): 1,615 km WNW of Laoag City, Ilocos 
+72 Hour (Tuesday morning): 1,615 km WNW of Laoag City, Ilocos
 Norte (Outside Par)
 
 Warning Signals
@@ -3648,13 +3648,13 @@ Tropical Storm ""JOLINA"" has weakened further after crossing the rugged terrain
 
 Estimated rainfall amount is from moderate to heavy within the 300-km diameter of the Tropical Storm.
 
-Meanwhile, monsoon rains are expected over the western sections of Central and Southern Luzon, while light to moderate with possible occasionally heavy rains due to thunderstorms will prevail over the rest of Luzon. Residents in these areas, as well as those under Tropical Cyclone Warning Signals 2 and 1,  are alerted against possible flashfloods and landslides. 
+Meanwhile, monsoon rains are expected over the western sections of Central and Southern Luzon, while light to moderate with possible occasionally heavy rains due to thunderstorms will prevail over the rest of Luzon. Residents in these areas, as well as those under Tropical Cyclone Warning Signals 2 and 1,  are alerted against possible flashfloods and landslides.
 
 Expected to exit in the northwestern boundary of PAR tonight.
 
 Sea travel is risky over the seaboards of Northern and Central Luzon.
 
-Location: At 7:00 AM today, the center of Tropical Storm “JOLINA” was at 75 km West Southwest of Laoag City, Ilocos Norte 
+Location: At 7:00 AM today, the center of Tropical Storm “JOLINA” was at 75 km West Southwest of Laoag City, Ilocos Norte
 
 Strength: Maximum sustained winds of 65 kph near the center and gustiness of up to 80 kph
 
@@ -3692,7 +3692,7 @@ Strength: Max sustained winds of up to 80kph near the center and gustiness of up
 
 Movement: West Northwest at 24kph.
 
-Positions: 
+Positions:
 24 Hour (Tomorrow morning): 735 km West Northwest of Laoag City, Ilocos Norte (OUTSIDE PAR)
 
 48 Hour (Monday morning): 1,185 km West Northwest of Laoag City, Ilocos Norte (OUTSIDE PAR)
@@ -3712,7 +3712,7 @@ Tropical Storm ""JOLINA"" has to move northwestward and is about to exit The Phi
 
 Estimated rainfall amount is from moderate to heavy within the 300-km diameter of the Tropical Storm.
 
-Light to moderate with possible occasionally heavy rains due to thunderstorms will prevail over Ilocos region, and the province of Zambales, Bataan, and Metro Manila. 
+Light to moderate with possible occasionally heavy rains due to thunderstorms will prevail over Ilocos subnational, and the province of Zambales, Bataan, and Metro Manila.
 
 All Tropical Cyclone Warning Signals are now lifted.
 
@@ -3723,7 +3723,7 @@ Strength: Maximum sustained winds of 80 kph near the center and gustiness of up 
 Movement: Northwest at 24 kph
 
 Positions:
-24 Hour (Tomorrow afternoon): 860 km West Northwest of Laoag City, Ilocos Norte 
+24 Hour (Tomorrow afternoon): 860 km West Northwest of Laoag City, Ilocos Norte
 
 48 Hour (Monday afternoon): 1,405 km West Northwest of Laoag City, Ilocos Norte
 
@@ -3768,7 +3768,7 @@ Location: at 4:00 pm today, the center of Tropical Depression ""KIKO"" was at 49
 
 Strength: Maximum winds of up to 55 kph near the center and gustiness of up to 65 kph.
 
-Movement: West Northwest at 15 kph. 
+Movement: West Northwest at 15 kph.
 
 Forecast positions:
 24 hour (Tomorrow afternoon): 230 km East of Aparri, Cagayan
@@ -3793,7 +3793,7 @@ Issued at 11:00 pm, 04 September 2017
 Kiko has maintained its strength as it moves towards Extreme Northern Luzon.
 Estimated rainfall amount is from moderate to heavy within the 300 km diameter of the Tropical Depression.
 
-Expected to pass Extreme northern Luzon by Tuesday midnight and expected to exit PAR by Wednesday evening. 
+Expected to pass Extreme northern Luzon by Tuesday midnight and expected to exit PAR by Wednesday evening.
 
 Meanwhile, moderate to occasionally heavy rains is expected over northern Luzon by tomorrow evening. Residents in these areas advised to be alert againts possible flashfloods and landslides.
 
@@ -3801,7 +3801,7 @@ Location of eye/center: At 10 PM today, the center of Tropical Depression ""KIKO
 Strength: Max. sustained winds of 55 kph near the center and gustiness of up to 65 kph
 Forecast Movement: Forecast to move West Northwest at 17 kph
 
-Forecast Positions: 
+Forecast Positions:
 24 Hr (Tomorrow evening): 150 km East Northeast of Aparri, Cagayan
 48 Hr (Wednesday evening):210 km West of Basco, Batanes
 72 Hr (Thursday evening): 590 km West Northwest of Basco, Batanes
@@ -3824,9 +3824,9 @@ Kiko has maintained its strength as it continues to move towards Extreme Norther
 
 Estimated rainfall amount is from moderate to heavy within the 300 km diameter of the Tropical Depression.
 
-Expected to pass Extreme northern Luzon by Wednesday morning and expected to exit PAR by Wednesday evening. 
+Expected to pass Extreme northern Luzon by Wednesday morning and expected to exit PAR by Wednesday evening.
 
-Meanwhile, moderate to occasionally heavy rains is expected over northern Luzon beginning today. 
+Meanwhile, moderate to occasionally heavy rains is expected over northern Luzon beginning today.
 
 Residents in these areas advised to be alert againts possible flashfloods and landslides. Sea travel is risky over the eastern seaboard of northern and central Luzon due to approaching Tropical Depression.
 
@@ -3836,7 +3836,7 @@ Strength: Maximum sustained winds of 55 kph near the center and gustiness of up 
 
 Forecast Movement: Forecast to move West Northwest at 15 kph
 
-Forecast Positions: 
+Forecast Positions:
 24 Hr (Tom, morning): 60 km East of Calayan, Cagayan
 48 Hr (Thurs, morning):455 km West Northwest of Basco, Batanes (OUTSIDE PAR)
 72 Hr (Friday morning): 945 km Northwest of Basco, Batanes (OUTSIDE PAR)
@@ -3859,7 +3859,7 @@ Tropical Depression “KIKO”
 
 Estimated rainfall amount is from moderate to heavy within the 300-km diameter of the Tropical Depression.
 
-Expected to pass Extreme northern Luzon by tomorrow morning and expected to exit PAR by tomorrow evening. 
+Expected to pass Extreme northern Luzon by tomorrow morning and expected to exit PAR by tomorrow evening.
 
 Meanwhile, moderate to occasionally heavy rains is expected today over northern Luzon. Residents in these areas are advised to be alert against possible flashfloods and landslides.
 
@@ -3872,7 +3872,7 @@ Movement: Northwest at 15 kph
 
 
 Positions:
-24 Hour (Tomorrow morning): 55 km South Southwest of Basco, Batanes. 
+24 Hour (Tomorrow morning): 55 km South Southwest of Basco, Batanes.
 
 48 Hour (Thursday morning):625 km North of Basco, Batanes (OUTSIDE PAR).
 
@@ -3889,7 +3889,7 @@ OPERATIONS CENTER
 Tropical Depression “KIKO”
 ",alert,actual,public,geo,immediate,extreme,observed,2017-09-05 03:29:20,2017-09-05 03:00:00,2017-09-05 03:00:00,2017-09-05 06:00:00,2017-09-05 03:19:05,2017-09-05 03:19:05
 352,96,0,NZL,en,General Notifications,Northland CDEM test for JSON feed,"[Northland Civil Defence] 3.55pm Tues 5 Sept
-Test for JSON feed. 280 characters is the target length and now that the Hazard app is integrated with other platforms, we would normally include a link for further info. 
+Test for JSON feed. 280 characters is the target length and now that the Hazard app is integrated with other platforms, we would normally include a link for further info.
 www.nrc.govt.nz/evacuatenow is the page we would use in the event of an immediate evacuation","{""type"":""Polygon"",""coordinates"":[[[166.32202148438,-50.455755322309],[165.96084594727,-50.494210576014],[165.87295532227,-50.607645676897],[165.93063354492,-50.68514775244],[165.80291748047,-50.803331051476],[165.92239379883,-50.954966484949],[166.12976074219,-50.967940852515],[166.36734008789,-50.839768561905],[166.27395629883,-50.702546359775],[166.40441894531,-50.550962242982],[166.32202148438,-50.455755322309]]]}",Auckland Islands,alert,test,public,geo,immediate,extreme,observed,2017-09-05 03:53:16,2017-09-05 03:55:00,2017-09-05 03:55:00,2017-09-15 05:00:00,2017-09-05 03:44:41,2017-09-05 03:44:41
 353,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #5 as of 5: 00 PM, Sept 5, 2017
 Tropical Depression “KIKO”
@@ -3900,7 +3900,7 @@ Tropical Depression “KIKO”
 
 Estimated rainfall amount is from moderate to heavy within the 300-km diameter of the tropical depression.
 
-Expected to pass near Extreme Northern Luzon beginning tonight and close to Batanes tomorrow morning and expected to exit par by tomorrow late evening or Thursday (September 7, 2017) early morning. 
+Expected to pass near Extreme Northern Luzon beginning tonight and close to Batanes tomorrow morning and expected to exit par by tomorrow late evening or Thursday (September 7, 2017) early morning.
 
 Residents of Northern Luzon especially those under TCWS1 are alerted against possible flashfloods and landslides due to moderate to heavy rains.
 
@@ -3910,7 +3910,7 @@ Strength: Max sustained winds of 55 kph near the center and gustiness of up to 6
 
 Movement: Northwest at 19 kph
 
-Positions: 
+Positions:
 24 Hour (Tomorrow afternoon): 155 km Northwest of Basco, Batanes.
 
 48 Hour (Thursday afternoon): 965 km North of Basco, Batanes (OUTSIDE PAR)
@@ -3936,7 +3936,7 @@ Issued 11 pm, Sept. 5, 2017
 
 Est. rainfall amount is from moderate to heavy within the 250 km diameter of the Tropical Depression.
 
-Expected to be near Batanes area tomorrow morning and to exit PAR by tomorrow late evening or Thursday early morning. 
+Expected to be near Batanes area tomorrow morning and to exit PAR by tomorrow late evening or Thursday early morning.
 
 Location: At 10 PM today, the center of Tropical Depression ""KIKO"" was estimated at 105 km East Northeast of Calayan, Cagayan
 
@@ -3944,7 +3944,7 @@ Strength: Max. sustained winds of 55 kph near the center and gustiness of up to 
 
 Forecast movement: to move North Northwest at 19 kph
 
-Forecast Positions: 
+Forecast Positions:
 24 Hr (Tom, evening): 350 km NW of Basco, Batanes (OUTSIDE PAR)
 48 Hr (Thurs, evening):650 km NNW of Basco, Batanes (OUTSIDE PAR)
 72 Hr (Fri, evening): 1,245 km North Northeast of Basco, Batanes (OUTSIDE PAR)
@@ -3973,7 +3973,7 @@ Strength: Max. sustained winds of 55 kph near the center and gustiness of up to 
 
 Forecast movement: to move North Northwest at 20 kph
 
-Forecast Positions: 
+Forecast Positions:
 24 Hr (Tom, morning): 500 km North Northwest of Basco, Batanes (OUTSIDE PAR)
 48 Hr (Thurs, evening): 750 km North Northwest of Basco, Batanes (OUTSIDE PAR)
 72 Hr (Fri, evening): 1,080 km North Northwest of Basco, Batanes (OUTSIDE PAR)
@@ -4030,19 +4030,19 @@ Sent by: Emergency.AucklandCivilDefence@aucklandcouncil.govt.nz
 AUCKLAND - NO EVACUATION is required following the recent earthquake 8.0 Magnitude Earthquake has occurred of the west coast of Mexico
 
 * Share this message * Tell family and friends
-* Listen to your radio * Check for updates on Twitter and Facebook  
- 
+* Listen to your radio * Check for updates on Twitter and Facebook
+
 ALWAYS remember: If you are at the coast and felt an earthquake that was too hard to stand up in or lasted longer than one minute, EVACUATE to high ground or as far inland as possible.
- 
+
 WHAT ADVICE SHOULD I FOLLOW?
 National warnings and threats (including marine and land) are issued by the Ministry of Civil Defence and Emergency Management.
- 
-Auckland Civil Defence and Emergency Management uses this, and other information, to determine if evacuation is required for the Auckland region.","{""type"":""Polygon"",""coordinates"":[[[174.7265625,-36.182224980422],[174.04541015625,-36.514051199432],[174.58923339844,-37.309014074276],[175.3857421875,-37.050793129807],[175.2099609375,-36.690446235235],[175.18798828125,-36.377067839837],[175.62744140625,-36.403599620733],[175.59997558594,-36.071302299422],[175.27038574219,-36.022446681758],[174.7265625,-36.182224980422]]]}",Auckland,alert,actual,public,geo,immediate,extreme,observed,2017-09-08 05:28:37,2017-09-08 05:30:00,2017-09-08 05:30:00,2017-09-09 12:00:00,2017-09-08 05:19:54,2017-09-08 05:19:54
+
+Auckland Civil Defence and Emergency Management uses this, and other information, to determine if evacuation is required for the Auckland subnational.","{""type"":""Polygon"",""coordinates"":[[[174.7265625,-36.182224980422],[174.04541015625,-36.514051199432],[174.58923339844,-37.309014074276],[175.3857421875,-37.050793129807],[175.2099609375,-36.690446235235],[175.18798828125,-36.377067839837],[175.62744140625,-36.403599620733],[175.59997558594,-36.071302299422],[175.27038574219,-36.022446681758],[174.7265625,-36.182224980422]]]}",Auckland,alert,actual,public,geo,immediate,extreme,observed,2017-09-08 05:28:37,2017-09-08 05:30:00,2017-09-08 05:30:00,2017-09-09 12:00:00,2017-09-08 05:19:54,2017-09-08 05:19:54
 358,96,0,NZL,en,General Notifications,No tsunami threat to New Zealand from earthquake off the coast of Mexico,"[Northland Civil Defence] 6.04pm Fri 8 Sept
-The Ministry of Civil Defence & Emergency Management and GNS Science have advised that there is no tsunami threat to New Zealand from the 8.2M earthquake off the coast of Mexico.","{""type"":""Polygon"",""coordinates"":[[[174.8913570866,-36.004673486702],[173.94103970379,-36.531708849149],[172.52929653972,-35.16033672813],[172.35351528972,-34.347971491245],[173.0017086491,-34.21180215769],[174.21020474285,-34.867904962569],[174.8913570866,-36.004673486702]]]}",Northland region ,alert,actual,public,geo,immediate,extreme,observed,2017-09-08 06:05:31,2017-09-08 06:04:00,2017-09-08 06:04:00,2017-09-08 21:00:00,2017-09-08 05:56:49,2017-09-08 05:56:49
+The Ministry of Civil Defence & Emergency Management and GNS Science have advised that there is no tsunami threat to New Zealand from the 8.2M earthquake off the coast of Mexico.","{""type"":""Polygon"",""coordinates"":[[[174.8913570866,-36.004673486702],[173.94103970379,-36.531708849149],[172.52929653972,-35.16033672813],[172.35351528972,-34.347971491245],[173.0017086491,-34.21180215769],[174.21020474285,-34.867904962569],[174.8913570866,-36.004673486702]]]}",Northland subnational ,alert,actual,public,geo,immediate,extreme,observed,2017-09-08 06:05:31,2017-09-08 06:04:00,2017-09-08 06:04:00,2017-09-08 21:00:00,2017-09-08 05:56:49,2017-09-08 05:56:49
 359,96,0,NZL,en,General Notifications,National Warning: Tsunami  threat to beach and marine areas - no threat to Nelson Tasman,"[Nelson Tasman CDEM] There is a beach and marine tsunami threat warning in effects for the Chatham Islands, Pegasus Bay, Northern Coasts of Hawkes Bay and East Cape.
 
-There are no issues or warnings in place for the Nelson Tasman region.
+There are no issues or warnings in place for the Nelson Tasman subnational.
 For further information, refer to the MCDEM website www.civildefence.govt.nz","{""type"":""Polygon"",""coordinates"":[[[173.00407100469,-40.539268947302],[172.67448116094,-40.475618050776],[172.51754142344,-40.582962636158],[172.37625740469,-40.686178272091],[172.17745961621,-40.820918024279],[172.09374384955,-40.907991206871],[172.11467279121,-41.061999113455],[172.12252797559,-41.158970820706],[172.25700069219,-41.196181807757],[172.18899529427,-41.294523571281],[172.12620846927,-41.34559786526],[172.24129032344,-41.377014612721],[172.40350328386,-41.412330076925],[172.44008794427,-41.463311976686],[172.35115360469,-41.529923328154],[172.28836677969,-41.631662047767],[172.22036138177,-41.694203568269],[172.08435058594,-41.760576917301],[172.08956899121,-41.838587653673],[172.06864004955,-41.920386407],[172.08956899121,-42.005958348794],[172.13664544746,-42.075882325599],[172.23607175052,-42.126339799487],[172.33022466302,-42.180665109925],[172.34071645886,-42.281373021935],[172.45057974011,-42.327808720713],[172.52380371094,-42.242670673776],[172.63366699219,-42.126339799487],[172.70689062774,-42.064260928463],[172.75396708399,-42.040930080052],[172.91618037969,-41.791792682629],[173.02604366094,-41.694203568269],[173.17776482552,-41.541683191304],[173.35041493177,-41.38876110645],[173.49845577031,-41.252041198381],[173.60831905156,-41.03142520044],[173.35250236094,-41.138868158919],[173.16936012357,-41.004775422229],[173.08569934219,-40.894123736668],[173.03856790066,-40.826862282761],[172.931066975,-40.778544788093],[172.87877194583,-40.830021211908],[172.76890866458,-40.774593023517],[172.7113404125,-40.727028506769],[172.69568469375,-40.659597571928],[172.69568469375,-40.596061005914],[172.75841653347,-40.540437816833],[173.00407100469,-40.539268947302]]]}",Nelson Tasman,alert,actual,public,geo,immediate,extreme,observed,2017-09-08 19:35:44,2017-09-09 12:00:00,2017-09-08 18:00:00,2017-09-10 19:00:00,2017-09-08 19:27:02,2017-09-08 19:27:02
 360,165,0,PHL,en,General Notifications,"Tropical Cyclone Advisory #2 as of 11 AM, Sept. 10, 2017
 Tropical Storm “TALIM”
@@ -4130,10 +4130,10 @@ OPERATIONS CENTER
 For: Typhoon “LANNIE” (TALIM)
 ",alert,actual,public,geo,immediate,extreme,observed,2017-09-11 09:24:28,2017-09-11 09:00:00,2017-09-11 09:00:00,2017-09-11 12:00:00,2017-09-11 09:16:24,2017-09-11 09:16:24
 363,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #1 as of 5:00 pm, September 11, 2017
-For: Tropical Depression “MARING”. 
+For: Tropical Depression “MARING”.
 
 ","Severe Weather Bulletin #1 as of 5:00 pm, September 11, 2017
-For: Tropical Depression “MARING”. 
+For: Tropical Depression “MARING”.
 
 The Low-Pressure Area (LPA) East of Southern Luzon has developed into a Tropical Depression and was named ""MARING"".
 
@@ -4148,7 +4148,7 @@ Strength: Max sustained winds of up to 45 kph near the center and gustiness of u
 Movement: West Northwest at 13 kph.
 
 Positions:
-24 Hour (Tomorrow afternoon): In the vicinity of Maria Aurora, Aurora 
+24 Hour (Tomorrow afternoon): In the vicinity of Maria Aurora, Aurora
 
 48 Hour (Wednesday afternoon):180 km West Northwest of Dagupan City, Pangasinan
 
@@ -4164,7 +4164,7 @@ OPERATIONS CENTER
 
 
 ","{""type"":""Polygon"",""coordinates"":[[[117.158203125,15.834535741222],[121.904296875,21.902277966669],[130.8251953125,4.1711154548674],[121.728515625,4.8720477002419],[113.5546875,9.4490618268814],[117.158203125,15.834535741222]]]}","Severe Weather Bulletin #1 as of 5:00 pm, September 11, 2017
-For: Tropical Depression “MARING”. 
+For: Tropical Depression “MARING”.
 
 ",alert,actual,public,geo,immediate,extreme,observed,2017-09-11 10:16:33,2017-09-11 09:00:00,2017-09-11 09:00:00,2017-09-11 12:00:00,2017-09-11 10:08:11,2017-09-11 10:08:11
 364,165,0,PHL,en,General Notifications,"Severe Weather Bulletin No. 2
@@ -4175,11 +4175,11 @@ Issued at 8pm, Sept. 11, 2017
 
 Tropical Depression ""Maring"" has maintained its strength as it continues to move in a WNW direction.
 
-Moderate to occasionally heavy rains starting today will be experienced over Bicol region, CALABARZON, MIMAROPA, Metro Manila, Central Luzon, Pangasinan.
+Moderate to occasionally heavy rains starting today will be experienced over Bicol subnational, CALABARZON, MIMAROPA, Metro Manila, Central Luzon, Pangasinan.
 
 Expected to make landfall tomorrow afternoon over Quezon-Aurora area.
 
-Sea travel is risky over the Eastern seaboards of Aurora, Quezon, and Bicol region.
+Sea travel is risky over the Eastern seaboards of Aurora, Quezon, and Bicol subnational.
 
 Location of eye/center: At 7 PM today, the center of Tropical Depression MARING was estimated at 255 km East of Infanta, Quezon.
 
@@ -4210,11 +4210,11 @@ Issued at 11pm, Sept. 11, 2017
 
 Tropical Depression ""Maring"" has maintained its strength as it continues to move towards Quezon-Aurora area.
 
-Moderate to occasionally heavy rains starting today will be experienced over Bicol region, CALABARZON, MIMAROPA, Metro Manila, Central Luzon, Pangasinan.
+Moderate to occasionally heavy rains starting today will be experienced over Bicol subnational, CALABARZON, MIMAROPA, Metro Manila, Central Luzon, Pangasinan.
 
 Expected to make landfall tomorrow afternoon over Quezon-Aurora area.
 
-Sea travel is risky over the Eastern seaboards of Aurora, Quezon, and Bicol region.
+Sea travel is risky over the Eastern seaboards of Aurora, Quezon, and Bicol subnational.
 
 Location of eye/center: At 10PM today, the center of Tropical Depression MARING was estimated at 190km East of Infanta, Quezon.
 
@@ -4245,11 +4245,11 @@ Issued at 5 am, Sept. 12, 2017
 
 Tropical Depression ""Maring"" has slightly intensified as as it contiues to move towards Quezon-Aurora area.
 
-Moderate to occasionally heavy rains starting today will be experienced over Bicol region, CALABARZON, MIMAROPA, Metro Manila, Central Luzon, Pangasinan.
+Moderate to occasionally heavy rains starting today will be experienced over Bicol subnational, CALABARZON, MIMAROPA, Metro Manila, Central Luzon, Pangasinan.
 
 Expected to make landfall this afternoon over Quezon-Aurora area.
 
-Sea travel is risky over the Eastern seaboards of Aurora, Quezon, and Bicol region.
+Sea travel is risky over the Eastern seaboards of Aurora, Quezon, and Bicol subnational.
 
 Location of eye/center: At 4 AM today, the center of Tropical Depression MARING was estimated at 80 km North of Daet, Camarines Norte.
 
@@ -4260,7 +4260,7 @@ Movement: to move WNW at 11 kph.
 Forecast Positions:
 24 Hr (Tom., morning): In the vicinity of Agno, Pangasinan
 48 Hr (Wed, morning): 355 km WSW of Laoag City, Ilocos Norte
-72 Hr (Thurs. morning): 555 km West Northwest of Sinait, Ilocos Sur 
+72 Hr (Thurs. morning): 555 km West Northwest of Sinait, Ilocos Sur
 96 Hr (Sat. morning):825 km West Northwest of Sinait, Ilocos Sur
 120 Hr (Sun. morning):1,025 km Northwest of Sinait, Ilocos Sur
 
@@ -4427,7 +4427,7 @@ For Tropical Storm SAOLA
 
 The Tropical Storm with International Name ""Saola"" is about to enter the PAR and will be named ""Quedan"".
 
-Location of eye/center: At 10 AM today, the center of Tropical Storm with international name ""SAOLA"" was estimated at 1,200 km East of Virac, Catanduanes. 
+Location of eye/center: At 10 AM today, the center of Tropical Storm with international name ""SAOLA"" was estimated at 1,200 km East of Virac, Catanduanes.
 
 Strength: Max. sustained winds of 80 kph near the center and gustiness of up to 95 kph
 
@@ -4437,7 +4437,7 @@ Forecast Positions:
 24 Hr (Tom. morning): 1,085 km East of Casiguran, Aurora
 48 Hr (Fri, morning): 890 km East of Basco, Batanes
 72 Hr (Sat, morning): 900 km ENE of Basco, Batanes
-96 Hr (Sun, morning): 1,390 km NE of Basco, Batanes 
+96 Hr (Sun, morning): 1,390 km NE of Basco, Batanes
 
 No Tropical Cyclone Warning Signal
 
@@ -4447,21 +4447,21 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[119.92703408003,19.
 378,165,0,PHL,en,Typhoon Watch,Severe Weather Bulletin #3,"PAGASA Severe Weather Bulletin #3
 For TS ""SAOLA"" Quidan
 
-TS Quidan has intensified into a severe tropical storm while transversing over Philippine sea. 
+TS Quidan has intensified into a severe tropical storm while transversing over Philippine sea.
 
 Location of eye/center at 10:00 AM today, the center of Severe TS Quedan was at 1,155 km East of Aparri, Cagayan. With max sustained winds of up to 90 kph near the center and gustiness of up to 115 kph. Forecast to move Northwest at 21 kph.
 
 Forecast Positions:
-24 H (Tom morning): 775 km East Northeast of Basco, Batanes 
+24 H (Tom morning): 775 km East Northeast of Basco, Batanes
 48 H (Sat morning): 840 km Northeast of Basco, Batanes (Outside PAR)
 
-No tropical cyclone warning signal 
+No tropical cyclone warning signal
 
 Please report your situation or any untoward incidents to PRC OPCEN at 09188076734, Hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[121.376953125,20.879342971958],[116.9384765625,12.382928338487],[115.1806640625,8.450638800331],[119.00390625,7.2752923363722],[121.640625,7.6674414827261],[119.8828125,4.8720477002419],[122.958984375,5.5285105256928],[128.2763671875,5.2222465132274],[126.650390625,18.229351338387],[121.376953125,20.879342971958]]]}",Philippines ,alert,actual,public,geo,immediate,moderate,observed,2017-10-26 03:49:09,2017-10-26 03:00:00,2017-10-26 03:00:00,2017-10-26 15:00:00,2017-10-26 03:39:25,2017-10-26 03:39:25
 379,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #5
-For: Severe Tropical Storm Quedan 
+For: Severe Tropical Storm Quedan
 Issued 11am, Oct. 27, 2017","Severe Weather Bulletin #5
-For: Severe Tropical Storm Quedan 
+For: Severe Tropical Storm Quedan
 Issued 11am, Oct. 27, 2017
 
 Severe Tropical Storm ""Quedan"" has maintained in a nnw direction while traversing over Philippine sea.
@@ -4472,12 +4472,12 @@ Strength: Max. sustained winds of 90 kph near the center and gustiness of up to 
 
 Movement: to move NNW at 19 kph
 
-Forecast: 
-24 Hr (Tom. morning): 835 km NE of Basco, Batanes 
-48 Hr (Sun. morning):1,420 km NE of Basco, Batanes 
+Forecast:
+24 Hr (Tom. morning): 835 km NE of Basco, Batanes
+48 Hr (Sun. morning):1,420 km NE of Basco, Batanes
 72 Hr (Mon. morning): 2,045 km NE of Basco, Batanes
 
-No tropical cyclone warning signal 
+No tropical cyclone warning signal
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -4516,8 +4516,8 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.2783203125,20.097206227084],[118.3447265625,14.434680215297],[116.19140625,8.4941045375519],[116.8505859375,7.188100871179],[120.849609375,7.4496242601978],[119.4873046875,5.790896812872],[123.22265625,4.828259746867],[129.814453125,6.6646075621726],[128.7158203125,15.665354182093],[125.947265625,19.932041306116],[120.2783203125,20.097206227084]]]}","Luzon, Visayas, and Mindanao",update,actual,public,geo,immediate,moderate,observed,2017-10-28 03:14:04,2017-10-28 03:00:00,2017-10-28 03:00:00,2017-10-28 12:00:00,2017-10-28 03:04:18,2017-10-28 03:04:18
 382,165,0,PHL,en,Typhoon Watch,Severe Weather Bulletin #2,"PAGASA Severe Weather Bulletin #2
-For TD ""Ramil""  
-Issued at 8:00 AM, 01 November 2017 
+For TD ""Ramil""
+Issued at 8:00 AM, 01 November 2017
 
 The LPA South-Southwest of Masbate City, Masbate has developed into a TD and
 was named ""Ramil""
@@ -4529,8 +4529,8 @@ Forecast movement:
 48 H(Fri morning):155 km North Northeast of Pagasa Island, Palawan (Outside PAR)
 
 Tropical Cyclone Warning Signal :
-Signal No. 1: Metro Manila, Bicol region, CALABARZON, rest of MIMAROPA 
-Signal No. 1: (30-60kph expected in 36 hrs) (LUZON) Northern Palawan including Calamian Group of Islands,(VISAYAS) Aklan and Antique 
+Signal No. 1: Metro Manila, Bicol subnational, CALABARZON, rest of MIMAROPA
+Signal No. 1: (30-60kph expected in 36 hrs) (LUZON) Northern Palawan including Calamian Group of Islands,(VISAYAS) Aklan and Antique
 
 Please report your situation or any untoward incidents to PRC OPCEN at 09188076734, Hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[121.4208984375,20.797201434307],[118.4765625,15.072123545812],[115.5322265625,9.5790843358825],[115.3125,8.1027385777832],[118.4765625,7.4060477170763],[120.5419921875,8.276727101164],[120.4541015625,5.0033943450221],[124.6728515625,5.441022303718],[127.3095703125,5.9220446198833],[129.2431640625,7.2752923363722],[121.4208984375,20.797201434307]]]}",Phillippines ,alert,actual,public,geo,immediate,moderate,observed,2017-11-01 00:31:01,2017-11-01 03:00:00,2017-11-01 00:00:00,2017-11-02 16:00:00,2017-11-01 00:21:05,2017-11-01 00:21:05
 383,165,0,PHL,en,General Notifications,"PAGASA Severe Weather Forecast
@@ -4588,7 +4588,7 @@ Movement: West at 15 kph
 
 NO Tropical Cyclone Warning Signal
 
-Position: 
+Position:
 24 Hour (Tomorrow morning): 155 km North Northeast of Pagasa Island, Palawan (OUTSIDE PAR).
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
@@ -4609,7 +4609,7 @@ Strength: Max. sustained winds of 65 kph near the center and gustiness of up to 
 
 Movement: Forecast to move West at 16 kph
 
-Forecast Position: 
+Forecast Position:
 24 Hr (Tomorrow morning): 130 km NNW of Pagasa Island, Palawan (Outside PAR)
 
 No Tropical Storm Warning Signal
@@ -4632,7 +4632,7 @@ Strength: Max sustained winds of up to 80 kph near the center and gustiness of u
 
 Movement: West at 20 kph.
 
-Positions: 
+Positions:
 24 Hour (Tomorrow evening): 330 km West Northwest of PAGASA Island, Palawan. (Outside PAR)
 
 NO TROPICAL CYCLONE WARNING SIGNAL
@@ -4641,11 +4641,11 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER
 ","{""type"":""Polygon"",""coordinates"":[[[118.1689453125,14.987239525774],[121.8603515625,22.228090416784],[131.3525390625,5.3972734076909],[120.4541015625,5.0471707369197],[113.37890625,8.6679180023631],[118.1689453125,14.987239525774]]]}","Severe Weather Bulletin # 10 as of 11 PM, November 2, 2017",alert,actual,public,geo,immediate,extreme,observed,2017-11-02 15:00:36,2017-11-02 15:00:00,2017-11-02 15:00:00,2017-11-02 18:00:00,2017-11-02 14:50:56,2017-11-02 14:50:56
-388,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #11- FINAL as of 4:00 AM, 03 November 2017 
-For: Severe Tropical Storm ""RAMIL"" (DAMREY)","Severe Weather Bulletin #11- FINAL as of 4:00 AM, 03 November 2017 
+388,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #11- FINAL as of 4:00 AM, 03 November 2017
+For: Severe Tropical Storm ""RAMIL"" (DAMREY)","Severe Weather Bulletin #11- FINAL as of 4:00 AM, 03 November 2017
 For: Severe Tropical Storm ""RAMIL"" (DAMREY)
 
-“RAMIL"" has intensified into a Severe Tropical Storm and is now outside The Philippine Area of Responsibility. 
+“RAMIL"" has intensified into a Severe Tropical Storm and is now outside The Philippine Area of Responsibility.
 
 Location: At 3:00 AM today, the center of Severe Tropical Storm ""RAMIL"" was at 240 km North of Pagasa Island, Palawan (OUTSIDE PAR).
 
@@ -4657,7 +4657,7 @@ NO TROPICAL CYCLONE WARNING SIGNAL
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
-OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[116.0595703125,16.762467717942],[122.8271484375,22.674847351189],[130.341796875,4.6530799182741],[118.6962890625,5.9220446198833],[112.1044921875,11.178401873712],[116.0595703125,16.762467717942]]]}","“RAMIL"" has intensified into a Severe Tropical Storm and is now outside The Philippine Area of Responsibility. 
+OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[116.0595703125,16.762467717942],[122.8271484375,22.674847351189],[130.341796875,4.6530799182741],[118.6962890625,5.9220446198833],[112.1044921875,11.178401873712],[116.0595703125,16.762467717942]]]}","“RAMIL"" has intensified into a Severe Tropical Storm and is now outside The Philippine Area of Responsibility.
 ",alert,actual,public,geo,immediate,extreme,observed,2017-11-02 20:31:16,2017-11-02 20:00:00,2017-11-02 20:00:00,2017-11-03 00:00:00,2017-11-02 20:21:43,2017-11-02 20:21:43
 389,165,0,PHL,en,General Notifications,Thunderstorm  Advisory No. 2 for Visayas Area,"PAGASA Thunderstorm Advisory
 Issued at 2:12 PM, 04 Nov 2017
@@ -4686,7 +4686,7 @@ For LPA
 
 Location: At 10:00 AM today, the LPA was at 450 km East of Guiuan, Eastern Samar.
 
-This weather system will bring scattered rain showers and thunderstorms over Eastern Visayas and the regions of Caraga and Davao tonight, which could bring flash floods and landslides. 
+This weather system will bring scattered rain showers and thunderstorms over Eastern Visayas and the subnationals of Caraga and Davao tonight, which could bring flash floods and landslides.
 
 Moreover, the LPA is likely to develop into a Tropical Depression (TD) within the next 24 to 36 hours.
 
@@ -4702,7 +4702,7 @@ The LPA East of Catarman, Northern Samar has developed into a Tropical Depressio
 Est. Rainfall Amount: moderate to heavy within the 200 km diameter of the TD
 Strength: sustained winds of 45 kph and gustiness of up to 80 kph.
 
-Location of eye/center: At 7:00 AM today, the center of TD Salome was estimated based on all available data at In the vicinity of Mondragon, Northern Samar. 
+Location of eye/center: At 7:00 AM today, the center of TD Salome was estimated based on all available data at In the vicinity of Mondragon, Northern Samar.
 
 Forecast to move WNW at 25 kph.
 
@@ -4728,7 +4728,7 @@ Forecast to move West Northwest at 25 kph
 
 At 10:00 AM today, the center of TD ""SALOME"" was at 50 km South Southwest of Juban, Sorsogon
 
-Forecast Positions:	
+Forecast Positions:
 24H (Tom morning): 195 km Southwest of Iba, Zambales
 48H (Sat morning): 505 km North of Pagasa Island, Palawan (OUTSIDE PAR
 72H (Sun morning): 775 km North Northwest of Pagasa Island, Palawan (OUTSIDE PAR)
@@ -4751,7 +4751,7 @@ Forecast to move WNW at 25 kph
 
 At 1 PM today, the center of TD ""SALOME"" was at 50 km WSW of Legazpi City, Albay.
 
-Forecast Positions:	
+Forecast Positions:
 24H (Tom morning): 245 km WSW of Iba, Zambales
 48H (Sat morning): 525 km North of Pagasa Island, Palawan
 72H (Sun morning): 690 km NNW of Pagasa Island, Palawan
@@ -4774,7 +4774,7 @@ Forecast to move West Northwest at 25 kph
 
 At 4:00 PM today, the center of Tropical Depression SALOME was estimated based on all available data at 65 km Southwest of Pili, Camarines Sur.
 
-Forecast Positions:	
+Forecast Positions:
 24H (Tom afternoon): 310 km West Northwestward of Iba, Zambales
 48H (Sat afternoon): 555 km North of Pagasa Island, Palawan (OUTSIDE PAR)
 72H (Sun afternoon): 770 km NNW of Pagasa Island, Palawan (OUTSIDE PAR)
@@ -4795,7 +4795,7 @@ Est. rainfall amount is from moderate to heavy w/in the 250 km diameter of the T
 
 Salome is expected to exit landmass tomorrow morning and to exit PAR by Saturday morning.
 
-Location of eye/center: At 10 PM today, the center of TS ""SALOME"" was estimated at the vicinity of Mataas na 
+Location of eye/center: At 10 PM today, the center of TS ""SALOME"" was estimated at the vicinity of Mataas na
 
 Kahoy, Batangas.
 
@@ -4808,11 +4808,11 @@ Forecast Positions:
 - 48 Hr (Sat. evening): 625 km NNW at of Pagasa Island, Palawan (Outside PAR)
 
 Storm Warning Signal
-#2 (61-120 kph expected in 24 hrs): Metro Manila, Bataan, Cavite, Laguna, Batangas and the northern section 
+#2 (61-120 kph expected in 24 hrs): Metro Manila, Bataan, Cavite, Laguna, Batangas and the northern section
 
 of Oriental and of Occidental Mindoro
 
-#1(30-60kph expected in 36 hrs): Bulacan, Pampanga, Southern Zambales, Rizal, Camarines Norte, Camarines 
+#1(30-60kph expected in 36 hrs): Bulacan, Pampanga, Southern Zambales, Rizal, Camarines Norte, Camarines
 
 Sur, Romblon, Marinduque, Quezon, rest of Oriental and Occidental Mindoro
 
@@ -4829,13 +4829,13 @@ SALOME has maintained its strength and is now off the coast of Zambales-Bataan.
 
 Salome is expected to exit PAR by tomorrow morning.
 
-Location of eye/center: At 4 AM today, the center of TS ""SALOME"" was estimated at 55 km SW of Subic, Zambales 
+Location of eye/center: At 4 AM today, the center of TS ""SALOME"" was estimated at 55 km SW of Subic, Zambales
 
 Strength: Max. sustained winds of 65 kph near the center and gustiness of up to 100 kph
 
 Movement: to move WNW at 20 kph.
 
-Forecast Positions: 
+Forecast Positions:
 - 24 Hr (Tom. morning): 620 km WNW of Ambulong, Batangas (Outside PAR)
 
 Storm Warning Signal
@@ -4857,7 +4857,7 @@ Forecast to move Northwest at 20 kph
 
 Location of eye/center: At 10:00 PM today, the center of Tropical Storm ""SALOME"" was at 340 km West Northwest of Iba, Zambales
 
-Forecast Positions:	
+Forecast Positions:
 24H (Tom evening): 635 km West Northwest of Iba, Zambales
 48H (Sun evening): 755 km North Northwest of Pagasa Island, Palawan
 72H (Mon evening): 875 km Northwest of Pagasa Island, Palawan
@@ -4867,8 +4867,8 @@ NO TROPICAL CYCLONE WARNING SIGNAL
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.673828125,21.371244370618],[132.802734375,5.0909441750334],[120.76171875,4.6968790268714],[114.9169921875,7.928674801364],[120.673828125,21.371244370618]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-11-10 15:39:34,2017-11-10 15:00:00,2017-11-10 15:00:00,2017-11-10 18:00:00,2017-11-10 15:29:31,2017-11-10 15:29:31
-400,165,0,PHL,en,General Notifications,SEVERE WEATHER BULLETIN,"SEVERE WEATHER BULLETIN #12 FINAL 
-FOR: Tropical Storm Salome 
+400,165,0,PHL,en,General Notifications,SEVERE WEATHER BULLETIN,"SEVERE WEATHER BULLETIN #12 FINAL
+FOR: Tropical Storm Salome
 ISSUED AT: 5AM, 11 Nov 2017
 
 TROPICAL STORM ""SALOME"" IS NOW OUTSIDE THE (PAR).
@@ -4888,7 +4888,7 @@ Forecast Positions:
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.849609375,21.125497636606],[131.396484375,5.7034479821495],[120.41015625,4.0834527720386],[115.224609375,8.1462428250344],[120.849609375,21.125497636606]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-11-10 21:20:17,2017-11-10 21:00:00,2017-11-10 21:00:00,2017-11-11 00:00:00,2017-11-10 21:10:14,2017-11-10 21:10:14
-401,165,0,PHL,en,General Notifications,Heavy Rainfall Warning for Mindanao,"PAGASA Heavy Rainfall Warning 
+401,165,0,PHL,en,General Notifications,Heavy Rainfall Warning for Mindanao,"PAGASA Heavy Rainfall Warning
 Due to: Trough of Low Pressure Area
 Issued at 8:55 AM, 12 Nov. 2017
 
@@ -4902,7 +4902,7 @@ Please report your situation or any untoward incident to PRC OPCEN at 0918807673
 Heavy rains are affecting over Iloilo, Capiz, Negros Occidental and its nearby areas which may persist for 1 to 2 hours.
 
 Please report your situation or any untoward incident to PRC OPCEN at 09188076734, Hotline 143 or (02) 7902300","{""type"":""Polygon"",""coordinates"":[[[122.12814331055,12.017830337768],[121.75598144531,11.836438569639],[121.76696777344,11.226898356402],[121.80541992188,10.428390862638],[122.31353759766,9.9417983453893],[122.34924316406,9.2403817149788],[123.55224609375,8.7792251284741],[123.50280761719,9.7848512507506],[123.94226074219,10.706490492563],[123.73352050781,11.587669416896],[122.82440185547,11.937226753541],[122.12814331055,12.017830337768]]]}",Visayas Area,alert,actual,public,geo,immediate,moderate,observed,2017-11-12 06:33:45,2017-11-12 08:00:00,2017-11-12 06:00:00,2017-11-12 08:00:00,2017-11-12 06:23:44,2017-11-12 06:23:44
-403,165,0,PHL,en,General Notifications,Thunderstorm Advisory,"Thunderstorm Advisory #2 
+403,165,0,PHL,en,General Notifications,Thunderstorm Advisory,"Thunderstorm Advisory #2
 Issued at: 2:44 PM, 14 November 2017
 
 Heavy rains with lightning and strong winds are expected over Metro Manila, Bulacan, Rizal and Laguna within the next 2 hours.
@@ -4914,7 +4914,7 @@ Expect light to moderate rains over Nueva Ecija, Pampanga, Cavite and Batangas w
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[118.828125,16.404470456702],[123.59619140625,16.256867330623],[124.03564453125,12.533115357277],[119.72900390625,12.425847783029],[118.828125,16.404470456702]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-11-14 07:24:03,2017-11-14 06:00:00,2017-11-14 06:00:00,2017-11-14 09:00:00,2017-11-14 07:13:57,2017-11-14 07:13:57
-404,165,0,PHL,en,General Notifications,Thunderstorm Advisory ,"Thunderstorm Advisory #1 
+404,165,0,PHL,en,General Notifications,Thunderstorm Advisory ,"Thunderstorm Advisory #1
 Issued at 10:04 AM, 15 November 2017
 
 Thunderstorm affecting portions of Dinagat Island, Surigao del Sur (Barobo, Hinatuan), Davao Oriental (Baganga, Gov. Generoso), Compostela Valley (Compostela), Sarangani(Glan, Malapatan, Alabel, Maasim), South Cotabato (General Santos City) and nearby areas which may persist 1 to 2 hours.
@@ -4922,7 +4922,7 @@ Thunderstorm affecting portions of Dinagat Island, Surigao del Sur (Barobo, Hina
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.2890625,7.8851472834243],[127.3974609375,11.005904459659],[126.9580078125,5.5722498011139],[123.310546875,4.959615024698],[121.2890625,7.8851472834243]]]}",MINDANAO,alert,actual,public,geo,immediate,extreme,observed,2017-11-15 02:39:55,2017-11-15 02:00:00,2017-11-15 02:00:00,2017-11-15 04:00:00,2017-11-15 02:29:47,2017-11-15 02:29:47
-405,165,0,PHL,en,General Notifications,Thunderstorm Advisory,"Thunderstorm Advisory #2 
+405,165,0,PHL,en,General Notifications,Thunderstorm Advisory,"Thunderstorm Advisory #2
 Issued at: 3:15 PM 15 November 2017
 
 Heavy rains with lightning and strong winds due to thunderstorms are expected over Batangas and Zambales within the next 2 hours.
@@ -4940,7 +4940,7 @@ Issued at 11 AM, 16 November 2017
 
 At 10:00 AM today, the Low Pressure Area (LPA) was at 150 km East Northeast of Hinatuan, Surigao del Sur.
 
-This weather system will bring scattered moderate to heavy rains over the regions of Caraga, Northern Mindanao, Zamboanga Peninsula, Eastern and Central Visayas and Lanao del Sur.
+This weather system will bring scattered moderate to heavy rains over the subnationals of Caraga, Northern Mindanao, Zamboanga Peninsula, Eastern and Central Visayas and Lanao del Sur.
 
 Moreover, the LPA is likely to develop into a Tropical Depression (TD) within the next 24 hours.
 
@@ -4951,7 +4951,7 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.7177734375,21.4
 Issued at 11:15 PM, 16 Nov. 2017
 
 Yellow Warning: Cebu and Bohol
-Flooding is possible in low-lying area and landslides in mountainous areas. 
+Flooding is possible in low-lying area and landslides in mountainous areas.
 
 All are advised to take precautionary measures against flash floods and landslides.
 
@@ -4960,7 +4960,7 @@ Please report your situation or any untoward incident to PRC OPCEN at 0918807673
 Issued at 11:15 PM, 16 Nov. 2017
 
 Yellow Warning: Biliran, Leyte, Southern Leyte and portions of Samar
-Flooding is possible in low-lying area and landslides in mountainous areas. 
+Flooding is possible in low-lying area and landslides in mountainous areas.
 
 All are advised to take precautionary measures against flash floods and landslides.
 
@@ -4972,7 +4972,7 @@ Red Warning: Cebu (Metro, Southern area)
 Flooding is expected in low-lying area and landslides in mountainous areas.
 
 Yellow Warning: Cebu (Northern area)
-Flooding is possible in low-lying area and landslides in mountainous areas. 
+Flooding is possible in low-lying area and landslides in mountainous areas.
 
 All are advised to take precautionary measures against flash floods and landslides.
 
@@ -5019,7 +5019,7 @@ NZRC TEST
 NZRC TEST
 ***TEST***","{""type"":""Polygon"",""coordinates"":[[[166.00616455078,-50.508186602591],[166.00067138672,-50.682537457817],[165.84136962891,-50.771207831888],[165.92651367188,-50.916887489245],[166.14349365234,-50.960156719546],[166.28082275391,-50.863177715136],[166.30279541016,-50.651201957454],[166.42639160156,-50.436516016986],[166.00616455078,-50.508186602591]]]}",Auckland Islands,alert,actual,public,geo,immediate,extreme,observed,2017-11-27 21:45:31,2017-11-27 22:00:00,2017-11-27 21:46:00,2017-11-28 04:00:00,2017-11-27 21:35:33,2017-11-27 21:35:33
 420,96,0,NZL,en,General Notifications,Test,[Emergency Management BOP] Test BOP for Duty Managers,"{""type"":""Polygon"",""coordinates"":[[[165.93200683594,-50.443513052458],[165.73425292969,-50.92035050944],[166.40441894531,-51.017210463642],[166.31103515625,-50.56579378238],[166.39343261719,-50.433017111357],[165.93200683594,-50.443513052458]]]}",Test BOP DM ,alert,test,public,geo,immediate,extreme,likely,2017-11-28 01:34:08,2017-11-27 11:00:00,2017-11-28 01:40:00,2017-11-29 01:41:00,2017-11-28 01:24:15,2017-11-28 01:24:15
-421,96,0,NZL,en,General Notifications,HBCDEM Test Chocolate alert,"[Hawkes Bay CDEM] This is a test alert from Hawke's Bay Civil Defence. 
+421,96,0,NZL,en,General Notifications,HBCDEM Test Chocolate alert,"[Hawkes Bay CDEM] This is a test alert from Hawke's Bay Civil Defence.
 No action is required, but please bring chocolate.","{""type"":""Polygon"",""coordinates"":[[[165.47058105469,-50.334942738433],[166.640625,-50.401515322782],[166.5966796875,-50.767733723505],[166.27807617188,-51.106971055031],[165.8056640625,-51.017210463642],[165.50354003906,-50.639010281259],[165.47058105469,-50.334942738433]]]}",Auckland Island,alert,test,public,geo,immediate,extreme,observed,2017-11-29 22:56:50,2017-11-30 23:00:00,2017-11-29 22:58:00,2017-12-01 11:00:00,2017-11-29 22:46:54,2017-11-29 22:46:54
 422,96,0,NZL,en,General Notifications,EXAMPLE: HBCDEM Test Alert,[Hawkes Bay CDEM] EXAMPLE: This is a test alert from Civil Defence Emergency Management. No action is required.,"{""type"":""Polygon"",""coordinates"":[[[165.9375,-50.584108586885],[165.84274291992,-50.826758482363],[165.90866088867,-50.916021693926],[166.12152099609,-50.952371229454],[166.26983642578,-50.865778001098],[166.26434326172,-50.757309850294],[166.21353149414,-50.679056768285],[166.37283325195,-50.578004443256],[166.36596679688,-50.532634604818],[166.32064819336,-50.474112921677],[166.10092163086,-50.502946097278],[165.9375,-50.584108586885]]]}",Auckland Island,alert,test,public,geo,immediate,extreme,observed,2017-11-29 22:57:21,2017-11-29 22:59:00,2017-11-29 22:59:00,2017-11-30 22:59:00,2017-11-29 22:47:47,2017-11-29 22:47:47
 423,96,0,NZL,en,General Notifications,HBCDEM Test Alert,[Hawkes Bay CDEM] This is a test alert from Civil Defence Emergency Management. No Action is required. Hannah ,"{""type"":""Polygon"",""coordinates"":[[[165.97595214844,-50.501199132933],[166.39617919922,-50.454006666287],[166.2451171875,-50.675575820586],[166.26983642578,-50.866644730858],[166.09130859375,-50.961886651321],[165.86883544922,-50.894371575548],[165.84411621094,-50.757309850294],[166.04736328125,-50.672094614712],[165.97595214844,-50.501199132933]]]}",Auckland Islands,alert,test,public,geo,immediate,extreme,observed,2017-11-29 22:57:49,2017-11-30 23:15:00,2017-11-29 23:00:00,2017-12-02 00:00:00,2017-11-29 22:48:17,2017-11-29 22:48:17
@@ -5044,9 +5044,9 @@ III- Guiuan, Lawaan, Eastern Samar
 No expected damages and aftershocks
 Source: PHIVOLCS","{""type"":""Polygon"",""coordinates"":[[[122.37670898438,12.929614580987],[126.14501953125,12.854648905589],[126.73828125,10.930404972956],[126.76025390625,9.9255659124055],[124.59594726562,9.2864646843041],[122.86010742188,8.8633620335517],[120.9814453125,10.930404972956],[122.37670898438,12.929614580987]]]}","014 km W of Salcedo, Eastern Samar",alert,actual,public,geo,immediate,extreme,observed,2017-12-06 04:00:19,2017-12-06 02:13:00,2017-12-06 02:13:00,2017-12-06 04:13:00,2017-12-06 03:50:24,2017-12-06 03:50:24
 432,165,0,PHL,en,General Notifications,"PAGASA Weather Advisory No.1
-For: Tail-end of a cold front and LPA","Tail-end of a cold front will bring to occasionally heavy rains over Bicol region, Eastern Visayas and the Province of Quezon.
+For: Tail-end of a cold front and LPA","Tail-end of a cold front will bring to occasionally heavy rains over Bicol subnational, Eastern Visayas and the Province of Quezon.
 
-LPA was est. based on all available data at 775km E of Davao City, Davao del Sur. It will bring cloudy skies w/ light to moderate rains and thunderstorm over the regions of CARAGA and Davao. This disturbance may develop into a Tropical Depression w/in the next 36-48 hrs.","{""type"":""Polygon"",""coordinates"":[[[121.79443359375,13.00455774534],[123.2666015625,14.796127603627],[125.88134765625,13.645986814875],[126.97998046875,9.7523701391733],[127.44140625,5.6597185545773],[124.013671875,4.9377242743025],[121.44287109375,8.3419530754668],[120.673828125,11.566143767763],[121.79443359375,13.00455774534]]]}",Visayas and Mindanao,alert,actual,public,geo,immediate,extreme,observed,2017-12-11 03:49:04,2017-12-11 02:00:00,2017-12-11 02:00:00,2017-12-11 06:00:00,2017-12-11 03:39:19,2017-12-11 03:39:19
+LPA was est. based on all available data at 775km E of Davao City, Davao del Sur. It will bring cloudy skies w/ light to moderate rains and thunderstorm over the subnationals of CARAGA and Davao. This disturbance may develop into a Tropical Depression w/in the next 36-48 hrs.","{""type"":""Polygon"",""coordinates"":[[[121.79443359375,13.00455774534],[123.2666015625,14.796127603627],[125.88134765625,13.645986814875],[126.97998046875,9.7523701391733],[127.44140625,5.6597185545773],[124.013671875,4.9377242743025],[121.44287109375,8.3419530754668],[120.673828125,11.566143767763],[121.79443359375,13.00455774534]]]}",Visayas and Mindanao,alert,actual,public,geo,immediate,extreme,observed,2017-12-11 03:49:04,2017-12-11 02:00:00,2017-12-11 02:00:00,2017-12-11 06:00:00,2017-12-11 03:39:19,2017-12-11 03:39:19
 433,165,0,PHL,en,General Notifications,"PAGASA Severe Weather Bulletin #1 Issued at 5 PM, 12 Dec. 2017
 For: TD ""Urduja""","PAGASA Severe Weather Bulletin #1Issued at 5 PM, 12 Dec. 2017
 For: TD ""Urduja"".
@@ -5084,7 +5084,7 @@ At 10:00 PM today, the center of TD ""URDUJA"" was at 415 km ENE of Hinatuan, Su
 
 Forecast to move NNW at 6 kph
 
-Forecast Positions:	
+Forecast Positions:
 24HR (Tom. evening): 415 km East of Guiuan, Eastern Samar
 48HR (Thur. evening): 295 km East of Guiuan, Eastern Samar
 72HR (Fri. evening): 155 km ENE of Borongan City, Eastern Samar
@@ -5096,7 +5096,7 @@ NO TROPICAL CYCLONE WARNING SIGNAL
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.76171875,21.616579336741],[130.3857421875,5.8783321096743],[119.7509765625,4.5216663426148],[115.3564453125,7.7980785313553],[120.76171875,21.616579336741]]]}",PHILIPPINES,alert,actual,public,geo,immediate,extreme,observed,2017-12-12 15:22:21,2017-12-12 15:00:00,2017-12-12 15:00:00,2017-12-12 18:00:00,2017-12-12 15:12:35,2017-12-12 15:12:35
-435,165,0,PHL,en,General Notifications,"Thunderstorm Advisory No. 2 for Mindanao Prov. 
+435,165,0,PHL,en,General Notifications,"Thunderstorm Advisory No. 2 for Mindanao Prov.
 Issued at 10:24 AM, 13 Dec. 2017","Thunderstorm affecting portions of Misamis Oriental, Bukidnon, Agusan del Norte, Agusan del Sur, Surigao del Norte, Surigao del Sur, Davao Oriental, Sultan Kudarat, Maguindanao, North Cotabato, Sarangani, Zamboanga del Norte,Zamboanga del Sur, Misamis Occidental, Basilan and nearby areas which may persist 1 to 2 hrs.
 
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
@@ -5105,7 +5105,7 @@ Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; La
 For: Tropical Depression Urduja
 Issued at 11:00 AM, 13 Dec 2017","TD Urduja has maintained its strength as it continues to move in NNW direction. It may intensify into a Tropical Storm within 36 hrs.
 
-As of 10 AM, TD Urduja was at 405 km East of Guiuan, Eastern Samar with max wind of 55 kph and gustiness of up to 65 kph moving NNW at 7 kph. 
+As of 10 AM, TD Urduja was at 405 km East of Guiuan, Eastern Samar with max wind of 55 kph and gustiness of up to 65 kph moving NNW at 7 kph.
 
 Moderate to heavy rainfall is expected w/in 350 km diameter of the Tropical Depression
 
@@ -5135,7 +5135,7 @@ At 10:00 PM today, the center of TD ""URDUJA"" was at 295 km East of Guiuan, Eas
 
 Forecast to move WNW at 7 kph
 
-Forecast Positions:	
+Forecast Positions:
 24HR (Tom. evening): 175 km East of Borongan City, Eastern Samar.
 48HR (Fri. evening): 145 km East Southeast of Catarman, Northern Samar
 72HR (Sat. evening): 60 km South of Legazpi City, Albay
@@ -5153,41 +5153,41 @@ Issued at 4 am, 14 December 2017","Severe Weather Bulletin #6
 For: Tropical Depression Urduja
 Issued at 4 am, 14 December 2017
 
-TD ""Urduja"" has slightly accelerated as it 
+TD ""Urduja"" has slightly accelerated as it
 
 approaches the Eastern Samar-Northern Samar area.
 
-Estimated rainfall amount is from moderate to 
+Estimated rainfall amount is from moderate to
 
 heavy within the 400 km diameter of the TD.
 
-At 4:00 AM today, the center of TD ""URDUJA"" was 
+At 4:00 AM today, the center of TD ""URDUJA"" was
 
-at 175 km East of Guiuan, Eastern Samar with winds 
+at 175 km East of Guiuan, Eastern Samar with winds
 
-of 55 kph near the center and gustiness of up to 65 
+of 55 kph near the center and gustiness of up to 65
 
 kph.
 
 Forecast to move West at 8 kph
 
-Forecast Positions:	
+Forecast Positions:
 24hr (Tom. morning): 70 km East Southeast of Borongan City, Eastern Samar.
 48hr (Sat. morning): In the vicinity of San Jose de Buan, Samar
 72hr (Sun. morning): 35 km South Southeast of Romblon, Romblon
 96HR (Mon. morning):55 km Southwest of Coron, Palawan
 120HR (Tues.morning):225 km West Northwest of Puerto Princesa City, Palawan
 
-Signal #1: 
+Signal #1:
 Visayas: Eastern Samar, Northern Samar, Samar, Biliran, Leyte, and Southern Leyte
 
 Bicol: Catanduanes, Albay, Sorsogon, and Masbate
 
-Kindly monitor and report any untoward incident to 
+Kindly monitor and report any untoward incident to
 
 PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
-OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.4541015625,19.725342248058],[118.7841796875,14.392118083662],[116.2353515625,7.3188817303668],[120.2783203125,8.4941045375519],[119.35546875,4.6092780844098],[129.8583984375,4.5216663426148],[128.8916015625,18.396230138029],[125.33203125,22.634292693794],[120.4541015625,19.725342248058]]]}",Bicol and Visayas region,alert,actual,public,geo,immediate,moderate,observed,2017-12-13 21:11:12,2017-12-13 20:00:00,2017-12-13 20:00:00,2017-12-13 23:00:00,2017-12-13 21:01:24,2017-12-13 21:01:24
+OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.4541015625,19.725342248058],[118.7841796875,14.392118083662],[116.2353515625,7.3188817303668],[120.2783203125,8.4941045375519],[119.35546875,4.6092780844098],[129.8583984375,4.5216663426148],[128.8916015625,18.396230138029],[125.33203125,22.634292693794],[120.4541015625,19.725342248058]]]}",Bicol and Visayas subnational,alert,actual,public,geo,immediate,moderate,observed,2017-12-13 21:11:12,2017-12-13 20:00:00,2017-12-13 20:00:00,2017-12-13 23:00:00,2017-12-13 21:01:24,2017-12-13 21:01:24
 439,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #7
 For: Tropical Depression Urduja
 Issued at 8 am, 14 December 2017","Severe Weather Bulletin #7
@@ -5196,28 +5196,28 @@ Issued at 8 am, 14 December 2017
 
 TD ""Urduja"" has accelerated further while moving closer towards Eastern Samar.
 
-Expected to make landfall over Eastern Samar between tonight and tomorrow morning. 
+Expected to make landfall over Eastern Samar between tonight and tomorrow morning.
 
 Estimated rainfall amount is from moderate to heavy within the 400 km diameter of the TD.
 
-At 7:00 AM today, the center of TD ""URDUJA"" was at 140 km East of Guiuan, Eastern Samar with winds 
+At 7:00 AM today, the center of TD ""URDUJA"" was at 140 km East of Guiuan, Eastern Samar with winds
 
 of 55 kph near the center and gustiness of up to 65 kph.
 
 Forecast to move West at 10 kph
 
-Forecast Positions:	
+Forecast Positions:
 24hr (Tom. morning): In the vicinity of Hinabangan, Samar
 48hr (Sat. morning): In the vicinity of San Julian, Eastern Samar
 72hr (Sun. morning): 70 km Southwest of Romblon, Romblon
 96HR (Mon. morning): 175 km North of Puerto Princesa City, Palawan
 
-Signal #1: 
+Signal #1:
 Visayas: Eastern Samar, Northern Samar, Samar, Biliran, Leyte, and Southern Leyte, Northern Cebu, Capiz, Aklan and Northern Iloilo
 
 Bicol: Catanduanes, Camarines Sur,Albay, Sorsogon, Masbate and Romblon
 
-Kindly monitor and report any untoward incident to 
+Kindly monitor and report any untoward incident to
 
 PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -5251,35 +5251,35 @@ Issued at 2 PM, 14 Dec 2017","""Urduja"" has intensified into a tropical storm a
 
 As of 1 PM, TS Urduja is at 90 km East of Guiuan, Eastern Samar with max wind of 65 kph and gustiness of 80 kph forecast to move West at 7 kph
 
-Moderate to heavy rainfall is expected w/in its 400 km diameter.  Scattered to widespread rains is expected over Visayas and the regions of Bicol, Caraga and Northern Mindanao w/in 24 hrs.
+Moderate to heavy rainfall is expected w/in its 400 km diameter.  Scattered to widespread rains is expected over Visayas and the subnationals of Bicol, Caraga and Northern Mindanao w/in 24 hrs.
 
-Forecast Positions: 
+Forecast Positions:
 24H (Tom morning): Borongan City, Eastern Samar
 48H (Sat morning): 90 km ENE of Roxas City, Capiz
 72H (Sun morning): 160 km NE of Puerto Princesa City, Palawan
 
 WARNING SIGNAL
-TCWS #2 
+TCWS #2
 Eastern Samar, Samar, Biliran
 
-TCWS#1 
+TCWS#1
 Catanduanes, Camarines Sur, Albay, Sorsogon, Masbate and Romblon Northern Samar, Leyte, and Southern Leyte, Northern Cebu including Bantayan Island, Capiz, Aklan and Northern Iloilo
 
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER
 ","{""type"":""Polygon"",""coordinates"":[[[125.70556640625,5.5066396743549],[127.72705078125,7.1663003819032],[126.6064453125,11.178401873712],[125.17822265625,14.732386081418],[122.0361328125,15.538375926292],[122.9150390625,18.625424540701],[119.00390625,18.937464429642],[118.85009765625,15.792253570362],[119.90478515625,13.047372256949],[116.74072265625,9.3189901923979],[116.103515625,7.3188817303668],[120.1025390625,8.6896390681277],[120.849609375,11.910353555774],[121.92626953125,8.6679180023631],[120.08056640625,6.0313107071258],[118.89404296875,4.3025910771197],[122.255859375,3.8642546157214],[123.24462890625,6.7955350257195],[125.70556640625,5.5066396743549]]]}",Philippines,alert,actual,public,geo,immediate,moderate,observed,2017-12-14 07:06:30,2017-12-14 06:00:00,2017-12-14 06:00:00,2017-12-14 12:00:00,2017-12-14 06:56:42,2017-12-14 06:56:42
-443,165,0,PHL,en,General Notifications,Severe Weather Bulletin # 10 for ,"SWB # 10 for TS Urduja 
-Tropical Cyclone: WARNING 
-Issued at 5 PM, 14 Dec 2017 
+443,165,0,PHL,en,General Notifications,Severe Weather Bulletin # 10 for ,"SWB # 10 for TS Urduja
+Tropical Cyclone: WARNING
+Issued at 5 PM, 14 Dec 2017
 
 Tropical Storm ""URDUJA"" increases its threat in Samar Provinces and expected to make landfall over Eastern Samar tomorrow morning.
 
 As of 4 PM, TS Urduja is at 85 km ESE of Guiuan, Eastern Samar with max wind of 65 kph and gustiness of 90 kph forecast to move West at 7 kph
 
-Moderate to heavy rainfall is expected w/in the 400 km diameter. Scattered to widespread rains is expected over Visayas and the regions of Bicol, Caraga and Northern Mindanao w/in 24 hrs.
+Moderate to heavy rainfall is expected w/in the 400 km diameter. Scattered to widespread rains is expected over Visayas and the subnationals of Bicol, Caraga and Northern Mindanao w/in 24 hrs.
 
-Forecast positions: 
+Forecast positions:
 24H (Tom afternoon): Vicinity of Calbiga, Samar
 48H (Sat afternoon): 65 km ENE of Roxas City, Capiz
 72H (Sun afternoon): Vicinity of Taytay, Palawan
@@ -5297,9 +5297,9 @@ Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; La
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[126.54052734375,5.2222465132274],[127.11181640625,7.4060477170763],[126.9140625,10.358151400944],[125.0244140625,14.115267411123],[123.11279296875,15.834535741222],[123.3544921875,18.458768120015],[122.2119140625,20.427012814257],[119.68505859375,18.937464429642],[119.02587890625,15.474857402687],[119.3994140625,12.361465967347],[116.37817382812,8.5049702034421],[119.37744140625,4.6968790268714],[126.54052734375,5.2222465132274]]]}",Visayas Luzon,alert,actual,public,geo,expected,moderate,observed,2017-12-14 10:16:51,2017-12-14 09:00:00,2017-12-14 09:00:00,2017-12-14 12:00:00,2017-12-14 10:07:03,2017-12-14 10:07:03
 444,165,0,PHL,en,General Notifications,"SEVERE WEATHER BULLETIN #11
-FOR: Tropical Storm Urduja 
+FOR: Tropical Storm Urduja
 Issued at 8pm, December 14, 2017","SEVERE WEATHER BULLETIN #11
-FOR: Tropical Storm Urduja 
+FOR: Tropical Storm Urduja
 Issued at 8pm, December 14, 2017
 
 Tropical Storm URDUJA remains almost stationary and continues to bring damage over Eastern Visayas.
@@ -5324,9 +5324,9 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.63015639782,20.096946780992],[118.52078139782,14.264115337455],[115.92800796032,7.5800539380465],[121.86062514782,4.7841949980803],[132.45144546032,5.8343426633832],[129.24343764782,17.30842541001],[126.29910171032,21.289118190584],[120.63015639782,20.096946780992]]]}",Bicol and Visayas REgion,alert,actual,public,geo,immediate,moderate,observed,2017-12-14 13:07:10,2017-12-14 12:00:00,2017-12-14 12:00:00,2017-12-14 14:00:00,2017-12-14 12:57:23,2017-12-14 12:57:23
 445,165,0,PHL,en,General Notifications,"SEVERE WEATHER BULLETIN #12
-FOR: Tropical Storm Urduja 
+FOR: Tropical Storm Urduja
 Issued 11 pm, December 14, 2017","SEVERE WEATHER BULLETIN #12
-FOR: Tropical Storm Urduja 
+FOR: Tropical Storm Urduja
 Issued 11pm, December 14, 2017
 
 Tropical Storm ""URDUJA"" continues to bring rains over Eastern Visayas and Caraga while moving slowly.
@@ -5354,11 +5354,11 @@ Wave Height: (Open Sea) 1.25-4.0 meters
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
-OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[119.8828125,18.479609055832],[119.1796875,13.197164523282],[115.1806640625,7.3188817303668],[119.0478515625,7.4060477170763],[120.0146484375,4.8720477002419],[132.0556640625,5.7034479821495],[126.123046875,23.160563309048],[119.8828125,18.479609055832]]]}",Visayas and Bicol region,alert,actual,public,geo,immediate,moderate,observed,2017-12-14 15:44:36,2017-12-14 15:00:00,2017-12-14 15:00:00,2017-12-14 18:00:00,2017-12-14 15:34:48,2017-12-14 15:34:48
+OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[119.8828125,18.479609055832],[119.1796875,13.197164523282],[115.1806640625,7.3188817303668],[119.0478515625,7.4060477170763],[120.0146484375,4.8720477002419],[132.0556640625,5.7034479821495],[126.123046875,23.160563309048],[119.8828125,18.479609055832]]]}",Visayas and Bicol subnational,alert,actual,public,geo,immediate,moderate,observed,2017-12-14 15:44:36,2017-12-14 15:00:00,2017-12-14 15:00:00,2017-12-14 18:00:00,2017-12-14 15:34:48,2017-12-14 15:34:48
 446,165,0,PHL,en,General Notifications,"SEVERE WEATHER BULLETIN #14
-For Tropical Storm Urduja 
+For Tropical Storm Urduja
 Issued 5 am, Dec. 15, 2017","SEVERE WEATHER BULLETIN #14
-For Tropical Storm Urduja 
+For Tropical Storm Urduja
 Issued 5 am, Dec. 15, 2017
 
 Tropical Storm ""Urduja"" has slightly intensified as it continues to move slowly off the Eastern Coast of Samar Island.
@@ -5421,7 +5421,7 @@ Wave Height: (Open Sea) 1.25-4.0 meters
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
-OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.3662109375,19.103648251664],[117.4658203125,13.025965926334],[115.927734375,7.9721977143869],[121.2890625,4.0396178267684],[133.4619140625,5.3535213553373],[126.73828125,22.553147478403],[120.3662109375,19.103648251664]]]}",Bicol and Visayas region,alert,actual,public,geo,immediate,moderate,observed,2017-12-15 00:24:19,2017-12-15 00:00:00,2017-12-15 00:00:00,2017-12-15 02:00:00,2017-12-15 00:14:29,2017-12-15 00:14:29
+OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.3662109375,19.103648251664],[117.4658203125,13.025965926334],[115.927734375,7.9721977143869],[121.2890625,4.0396178267684],[133.4619140625,5.3535213553373],[126.73828125,22.553147478403],[120.3662109375,19.103648251664]]]}",Bicol and Visayas subnational,alert,actual,public,geo,immediate,moderate,observed,2017-12-15 00:24:19,2017-12-15 00:00:00,2017-12-15 00:00:00,2017-12-15 02:00:00,2017-12-15 00:14:29,2017-12-15 00:14:29
 448,165,0,PHL,en,General Notifications,"SEVERE WEATHER BULLETIN #19
 For Tropical Storm Urduja
 Issued 8pm, December 15, 2017","SEVERE WEATHER BULLETIN #19
@@ -5436,7 +5436,7 @@ Eye/center of typhoon: At 7 PM today, the center of Tropical Storm ""URDUJA"" wa
 
 Strength: Max. sustained winds of 75 kph near the center and gustiness of up to 90 kph to move NW at 5kph.
 
-Forecast Positions: 
+Forecast Positions:
 24 Hr (Tom. afternoon): 110 km Northeast of Borongan City, Eastern Samar
 48 Hr (Sun. afternoon):30 km Northeast of Roxas City, Capiz
 72 Hr (Mon. afternoon): In the vicinity of Taytay, Palawan.
@@ -5451,11 +5451,11 @@ Signal #1: Catanduanes, Camarines Sur, Albay, Sorsogon, Romblon, and Masbate inc
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
-OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.41015625,19.435514339098],[116.8505859375,12.726084296948],[117.4658203125,7.5367643220841],[122.34375,4.6092780844098],[130.60546875,5.2222465132274],[132.5390625,13.111580118252],[122.51953125,19.766703551717],[120.41015625,19.435514339098]]]}",Visayas and Bicol region,alert,actual,public,geo,immediate,moderate,observed,2017-12-15 13:11:59,2017-12-15 12:00:00,2017-12-15 12:00:00,2017-12-15 14:00:00,2017-12-15 13:02:14,2017-12-15 13:02:14
+OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.41015625,19.435514339098],[116.8505859375,12.726084296948],[117.4658203125,7.5367643220841],[122.34375,4.6092780844098],[130.60546875,5.2222465132274],[132.5390625,13.111580118252],[122.51953125,19.766703551717],[120.41015625,19.435514339098]]]}",Visayas and Bicol subnational,alert,actual,public,geo,immediate,moderate,observed,2017-12-15 13:11:59,2017-12-15 12:00:00,2017-12-15 12:00:00,2017-12-15 14:00:00,2017-12-15 13:02:14,2017-12-15 13:02:14
 449,165,0,PHL,en,General Notifications,"SEVERE WEATHER BULLETIN #22
-For Tropical Storm Urduja 
+For Tropical Storm Urduja
 Issued at 5 am, Dec. 16, 2017","SEVERE WEATHER BULLETIN #22
-For Tropical Storm Urduja 
+For Tropical Storm Urduja
 Issued at 5 am, Dec. 16, 2017
 
 ""URDUJA"" has slightly intensified and is now beginning to move closer towards Samar Island.
@@ -5464,7 +5464,7 @@ Expected to make landfall over Northern Samar - Eastern Samar area today. Est. r
 
 A possible raising of Storm Warning Signal #1 over Mindoro Provinces and Cuyo Islands within 6 hours.
 
-Eye/center of typhoon: At 4 AM today, the center of Tropical Storm ""URDUJA"" was estimated at 180 km ENE of Borongan City, Eastern Samar 
+Eye/center of typhoon: At 4 AM today, the center of Tropical Storm ""URDUJA"" was estimated at 180 km ENE of Borongan City, Eastern Samar
 
 Strength: Max. sustained winds of 80 kph near the center and gustiness of up to 95 kph to move WNW at 10 kph
 
@@ -5489,10 +5489,10 @@ TS""URDUJA"" has slightly accelerated and is now threatening SAMAR and SORSOGON 
 
 Expected to make landfall over Northern Samar - Eastern Samar area this afternoon.
 
-Scattered to widespread moderate to heavy rains will continue over Bicol Region and the Visayas and is expected to prevail over Southern Quezon, 
+Scattered to widespread moderate to heavy rains will continue over Bicol Region and the Visayas and is expected to prevail over Southern Quezon,
 Batangas, Cavite, Laguna, Mindoro Provinces, Marinduque, and Romblon.
 
-Location: At 10:00 AM today, the center of Tropical Storm ""URDUJA"" was at 75 km North Northeast of Borongan City, Eastern Samar or 120 km East-Southeast 
+Location: At 10:00 AM today, the center of Tropical Storm ""URDUJA"" was at 75 km North Northeast of Borongan City, Eastern Samar or 120 km East-Southeast
 of Catarman, Northern.
 
 Strength: Maximum sustained winds of 80 kph near the center and gustiness of up to 110 kph
@@ -5500,18 +5500,18 @@ Strength: Maximum sustained winds of 80 kph near the center and gustiness of up 
 Movement: West at 15 kph
 
 Positions:
-24 Hour (Tomorrow morning):50 km North Northwest of Roxas City, Capiz. 
+24 Hour (Tomorrow morning):50 km North Northwest of Roxas City, Capiz.
 
 48 Hour (Monday morning):185 km North Northeast of Puerto Princesa City, Palawan.
 
-72 Hour (Tuesday morning):245 km West Northwest of Puerto Princesa City, Palawan. 
+72 Hour (Tuesday morning):245 km West Northwest of Puerto Princesa City, Palawan.
 
-96 Hour (Wednesday morning):480 km West of Puerto Princesa City, Palawan (OUTSIDE PAR). 
+96 Hour (Wednesday morning):480 km West of Puerto Princesa City, Palawan (OUTSIDE PAR).
 
-TCWS 2- Albay, Sorsogon, and Masbate including Burias and Ticao Islands and Romblon, Northern Samar, Eastern Samar, Samar, Biliran, Leyte, Aklan, Capiz 
+TCWS 2- Albay, Sorsogon, and Masbate including Burias and Ticao Islands and Romblon, Northern Samar, Eastern Samar, Samar, Biliran, Leyte, Aklan, Capiz
 and Northen Iloilo
 
-TCWS 1- Southern Quezon, Mindoro, Marinduque, Catanduanes, Camarines Norte, Camarines Sur, Cuyo Islands and Calamian Group of Islands, Antique, 
+TCWS 1- Southern Quezon, Mindoro, Marinduque, Catanduanes, Camarines Norte, Camarines Sur, Cuyo Islands and Calamian Group of Islands, Antique,
 
 Rest of Iloilo, Guimaras, Negros Occidental, Northern Negros Oriental, Cebu, Northern Bohol, and Southern Leyte, Dinagat Islands
 
@@ -5531,7 +5531,7 @@ Strength: Maximum sustained winds of 80 kph near the center and gustiness of up 
 Movement: West at 15 kph
 
 
-Position: 
+Position:
 24 Hour (Tomorrow morning): 85 km West of Roxas City, Capiz.
 
 48 Hour (Monday morning):145 km North of Puerto Princesa City, Palawan.
@@ -5552,7 +5552,7 @@ OPERATIONS CENTER
 
 TS ""URDUJA"" has slightly weakened and is now traversing the Northern Part of Samar Province.
 
-Scattered to widespread moderate to heavy rains will continue over Bicol Region and the Visayas and is expected to prevail over Southern Quezon, Batangas, Cavite, Laguna, Mindoro Provinces, Marinduque, and Romblon. 
+Scattered to widespread moderate to heavy rains will continue over Bicol Region and the Visayas and is expected to prevail over Southern Quezon, Batangas, Cavite, Laguna, Mindoro Provinces, Marinduque, and Romblon.
 
 Tropical Depression outside PAR at 2,135 km. East of Mindanao.
 
@@ -5565,7 +5565,7 @@ Strength: Maximum sustained winds of 75 kph near the center and gustiness of up 
 Movement: West at 15 kph
 
 
-Positions: 
+Positions:
 24 Hour (Tomorrow afternoon): 95 km West of Roxas City, Capiz
 
 48 Hour (Monday afternoon):135 km North of Puerto Princesa City, Palawan
@@ -5583,7 +5583,7 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[115.7958984375,14.732386081418],[122.255859375,22.105998799751],[131.2646484375,4.828259746867],[121.11328125,4.5216663426148],[113.37890625,9.4490618268814],[115.7958984375,14.732386081418]]]}","Severe Weather Bulletin #26 as of 5:00 pm, Dec. 16, 2017",alert,actual,public,geo,immediate,extreme,observed,2017-12-16 09:53:31,2017-12-16 09:00:00,2017-12-16 09:00:00,2017-12-16 12:00:00,2017-12-16 09:43:48,2017-12-16 09:43:48
 453,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #27 as of 8:00 pm, December 16, 2017
 For TS URDUJA ","Severe Weather Bulletin #27 as of 8:00 pm, December 16, 2017
-For TS URDUJA 
+For TS URDUJA
 
 ""URDUJA"" continues to traverse the northern part of SAMAR PROVINCE.
 
@@ -5600,18 +5600,18 @@ Movement: West at 15 kph
 
 Positions:
 
-24 Hour (Tomorrow afternoon): 105 km Northeast of Cuyo, Palawan. 
+24 Hour (Tomorrow afternoon): 105 km Northeast of Cuyo, Palawan.
 
 48 Hour (Monday afternoon):145 km North Northwest of Puerto Princesa City, Palawan.
 
-72 Hour (Tuesday afternoon): 325 km West of Puerto Princesa City, Palawan. 
+72 Hour (Tuesday afternoon): 325 km West of Puerto Princesa City, Palawan.
 
 96 Hour (Wednesday afternoon):600 km West of Puerto Princesa City, Palawan (OUTSIDE PAR).
 
 
 TCWS #2- Sorsogon, Masbate including Ticao Island, Romblon, and Cuyo Islands, Northern Samar, Northern part of Samar, Biliran, Aklan, Capiz, Northern Antique, and Northern Iloilo.
 
-TCWS #1- Southern Quezon, Marinduque, Southern part of Occidental Mindoro, Southern part of Oriental Mindoro Catanduanes, Camarines Sur, Albay, Burias Island, and Northern Palawan including Calamian Group of Islands. Rest of Iloilo, Rest of Antique, Guimaras, Negros Occidental, Northern part of Negros Oriental, Northern Cebu, Leyte, Eastern Samar, and Rest of Samar. 
+TCWS #1- Southern Quezon, Marinduque, Southern part of Occidental Mindoro, Southern part of Oriental Mindoro Catanduanes, Camarines Sur, Albay, Burias Island, and Northern Palawan including Calamian Group of Islands. Rest of Iloilo, Rest of Antique, Guimaras, Negros Occidental, Northern part of Negros Oriental, Northern Cebu, Leyte, Eastern Samar, and Rest of Samar.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -5626,7 +5626,7 @@ Issued at 11 PM, 16 Dec 2017
 
 At 10 PM today, the center of TS ""URDUJA"" was at the vicinity of San Jose de Buan, Samar, with max. sustained winds of 65 kph near the center and gustiness of up to 110 kph. Forecast to move West at 13 kph.
 
-Forecast Positions:	
+Forecast Positions:
 24H(Tom. evening): 115 km ENE of Cuyo, Palawan
 48H(Mon evening):145 km North of Puerto Princesa City, Palawan
 72H(Tues. evening): 345 km West of Puerto Princesa City, Palawan
@@ -5686,11 +5686,11 @@ Scattered to widespread rains will continue over southern part of Mindoro Provin
 
 At 2 PM today, the TD outside the PAR was est. based on all available data at 1,950 km East of Mindanao w/ max sustained winds of 40 km/h near the center and gustiness of up to 50 km/h.
 
-Location : At 4 PM today, the center of TD ""URDUJA"" was est. at 65 km South of Romblon, Romblon 
+Location : At 4 PM today, the center of TD ""URDUJA"" was est. at 65 km South of Romblon, Romblon
 Strength: Max sustained winds of 55 kph near the center and gustiness of up to 80 kph
 Movement: Forecast to move West Southwest at 15 kph
 
-Forecast Positions: 
+Forecast Positions:
 24H (Tom afternoon): In the vicinity of Taytay, Palawan
 48H (Tue afternoon): 280 km West of Puerto Princesa City, Palawan
 72H (Wed afternoon): 275 km South Southwest of Pagasa Island, Palawan (outside PAR)
@@ -5734,7 +5734,7 @@ Strength: Maximum sustained winds of 55 kph near the center and gustiness of up 
 
 Movement: West at 18 kph
 
-Position: 
+Position:
 24 Hour (Tomorrow morning): 270 km West of Puerto Princesa City, Palawan.
 48 Hour (Wednesday morning):285 km South-Southwest of Pagasa Island, Palawan (OUTSIDE PAR)
 
@@ -5750,11 +5750,11 @@ Urduja has maintained its strength and is now over the West Philippine Sea.
 
 Scattered rains will continue over Palawan. Residents of these areas must undertake appropriate measures against flooding and landslides.
 
-Scattered rain showers and thunderstorms ls expected over provinces of Isabela, Aurora, and Quezon due to the effect of Tail-end of a cold front. Expected to exit PAR  tom morning or afternoon. At 3 PM today, the LPA was est. at 1,450 km East of Mindanao. 
+Scattered rain showers and thunderstorms ls expected over provinces of Isabela, Aurora, and Quezon due to the effect of Tail-end of a cold front. Expected to exit PAR  tom morning or afternoon. At 3 PM today, the LPA was est. at 1,450 km East of Mindanao.
 
 Location at 4 PM today, the center of TD ”URDUJA"" was est. at 120 km Northwest of Puerto Princesa City, Palawan w/ Max sustained winds of 45 kph near the center and gustiness of up to 60 kph forecast to move West Southwest at 18 kph
 
-Positions: 
+Positions:
 24H (Tom afternoon): 480 km West of Puerto Princesa City, Palawan (Outside PAR)
 48H (Wed afternoon):905 km West Southwest of Puerto Princesa City, Palawan (Outside PAR)
 
@@ -5770,7 +5770,7 @@ Tropical Depression ""URDUJA"" is now outside The Philippine Area of Responsibil
 
 Sea travel remains risky over the western seaboard of Palawan due to the surge of Northeast Monsoon.
 
-Meanwhile, at 8:00 AM today, the Low-Pressure Area outside the PAR was at 1,710 km East of Mindanao. This weather system has a possibility to enter PAR tomorrow (December 20). 
+Meanwhile, at 8:00 AM today, the Low-Pressure Area outside the PAR was at 1,710 km East of Mindanao. This weather system has a possibility to enter PAR tomorrow (December 20).
 
 Location: At 10:00 AM today, the center of Tropical Depression ""URDUJA"" was at 430 km West of Puerto Princesa City, Palawan (OUTSIDE PAR).
 
@@ -5779,7 +5779,7 @@ Strength: Maximum sustained winds of 45 kph near the center and gustiness of up 
 Movement: West Southwest at 18 kph
 
 Position:
-24 Hour (Tomorrow morning): 695 km West Southwest of Puerto Princesa City, Palawan (OUTSIDE PAR). 
+24 Hour (Tomorrow morning): 695 km West Southwest of Puerto Princesa City, Palawan (OUTSIDE PAR).
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -5844,7 +5844,7 @@ Issued at 5am, Dec. 21, 2017
 
 Vinta has intensified into a tropical storm as it continues to track westward.
 
-Scattered to widespread moderate to heavy rains is expected over Eastern Visayas, Caraga and Davao Region within 24 hours. 
+Scattered to widespread moderate to heavy rains is expected over Eastern Visayas, Caraga and Davao Region within 24 hours.
 
 Expected to make landfall over Caraga - Davao Region area between Thursday (Dec 21) evening and Friday (Dec 22) morning.
 
@@ -5852,7 +5852,7 @@ Location: At 4 AM today, the center of Tropical Storm ""VINTA"" was estimated at
 
 Strength: Maximum sustained winds of 65 kph near the center and gustiness of up to 80 kph to move West at 18 kph
 
-Forecast Positions: 
+Forecast Positions:
 24 Hr(Tom. morning): 80 km NE of Hinatuan, Surigao del Sur
 48 Hr(Sat. morning): 130 km West of Dipolog City, Zamboanga del Norte
 72 Hr(Sun. morning): 110 km SW of Puerto Princesa City
@@ -5874,7 +5874,7 @@ Issued at 8 am, December 21, 2017
 
 Vinta has maintained its strength as it moves towards the direction of Eastern Mindanao.
 
-Scattered to widespread moderate to heavy rains is expected over Central Visayas, Eastern Visayas, Caraga, Davao Region and Northern Mindanao within 24 hrs. 
+Scattered to widespread moderate to heavy rains is expected over Central Visayas, Eastern Visayas, Caraga, Davao Region and Northern Mindanao within 24 hrs.
 
 Expected to make landfall over Caraga - Davao Region area between this evening and tomorrow morning (22 Dec)
 
@@ -5924,7 +5924,7 @@ Mindanao: Dinagat Island, Camiguin, Misamis Oriental, Misamis Occidental, Bukidn
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[125.68359375,4.959615024698],[126.80419921875,6.2060904985739],[126.01318359375,11.974844752932],[124.34326171875,14.306969497826],[122.3876953125,15.411319377981],[122.93701171875,17.182779056432],[123.046875,19.539084135509],[121.22314453125,20.097206227084],[119.37744140625,18.417078658661],[119.20166015625,14.944784875088],[119.70703125,13.175771224423],[117.59765625,9.8606281453659],[116.03759765625,7.5803277913301],[118.05908203125,7.9721977143869],[121.00341796875,11.501556900932],[121.83837890625,9.7956775828297],[122.0361328125,8.7765107160523],[121.4208984375,7.0572823529716],[119.4873046875,5.5066396743549],[119.53125,4.1930296053608],[122.6513671875,5.812756913751],[123.24462890625,7.1226962775183],[123.662109375,6.0531612957141],[124.892578125,4.9158328013132],[125.68359375,4.959615024698]]]}",Philippines,alert,actual,public,geo,immediate,moderate,observed,2017-12-21 06:23:27,2017-12-21 03:00:00,2017-12-21 03:00:00,2017-12-21 08:00:00,2017-12-21 06:13:44,2017-12-21 06:13:44
-470,165,0,PHL,en,General Notifications,PAGASA Heavy Rainfall Warning No. 3  for TS Vinta,"PAGASA Heavy Rainfall Warning No. 3 
+470,165,0,PHL,en,General Notifications,PAGASA Heavy Rainfall Warning No. 3  for TS Vinta,"PAGASA Heavy Rainfall Warning No. 3
 Weather System: TS ""Vinta""
 Issued at: 1:30PM, 21 Dec 2017
 
@@ -5970,7 +5970,7 @@ TS Vinta slightly intensified and is now threatening CARAGA area.
 
 It is expected to make landfall over Caraga-Davao Region area between late this evening and tomorrow morning (Dec 22)
 
-Loc as of 7 PM, TS Vinta was at 130 km East of 
+Loc as of 7 PM, TS Vinta was at 130 km East of
 
 Hinatuan, Surigao del Sur with max winds of 805 kph with gustiness of 120 kph forecast to move west at 19 kph
 
@@ -5982,7 +5982,7 @@ Forecast Positions:
 
 Warning Signal
 #2
-Visayas: Siquijor and Southern Negros Oriental, Surigao del Norte Incl. Siargao Islands, Surigao del Sur, 
+Visayas: Siquijor and Southern Negros Oriental, Surigao del Norte Incl. Siargao Islands, Surigao del Sur,
 Mindanao: Agusan del Norte, Agusan del Sur, Northern Davao Oriental, Compostela Valley, Davao del Norte, Bukidnon, Misamis Oriental, Camiguin, Northern Zamboanga del Norte, Lanao del Norte, and Lanao del Sur
 
 #1
@@ -6000,7 +6000,7 @@ TS Vinta slightly intensified and is now threatening CARAGA area.
 
 It is expected to make landfall over Caraga-Davao Region area between late this evening and tomorrow morning (Dec 22)
 
-Loc as of 7 PM, TS Vinta was at 130 km East of 
+Loc as of 7 PM, TS Vinta was at 130 km East of
 
 Hinatuan, Surigao del Sur with max winds of 85 kph with gustiness of 120 kph forecast to move west at 19 kph
 
@@ -6012,7 +6012,7 @@ Forecast Positions:
 
 Warning Signal
 #2
-Visayas: Siquijor and Southern Negros Oriental, Surigao del Norte Incl. Siargao Islands, Surigao del Sur, 
+Visayas: Siquijor and Southern Negros Oriental, Surigao del Norte Incl. Siargao Islands, Surigao del Sur,
 Mindanao: Agusan del Norte, Agusan del Sur, Northern Davao Oriental, Compostela Valley, Davao del Norte, Bukidnon, Misamis Oriental, Camiguin, Northern Zamboanga del Norte, Lanao del Norte, and Lanao del Sur
 
 #1
@@ -6053,9 +6053,9 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.2783203125,19.435514339098],[118.8720703125,14.306969497826],[115.0927734375,8.1027385777832],[118.740234375,7.2316987083671],[122.34375,4.5654735507103],[128.4521484375,5.2660078828055],[129.55078125,18.479609055832],[124.189453125,20.550508894196],[120.2783203125,19.435514339098]]]}","Visayas, Mindanao and MIMAROPA",alert,actual,public,geo,immediate,extreme,observed,2017-12-21 15:21:38,2017-12-21 15:00:00,2017-12-21 15:00:00,2017-12-21 18:00:00,2017-12-21 15:11:58,2017-12-21 15:11:58
 475,165,0,PHL,en,General Notifications,"SWB #10
-For Severe Tropical Storm  Vinta 
+For Severe Tropical Storm  Vinta
 Issued at 2AM, Dec. 22, 2017","SWB #10
-For Severe Tropical Storm  Vinta 
+For Severe Tropical Storm  Vinta
 Issued at 2AM, Dec. 22, 2017
 
 STS Vinta has made landfall in Cateel, Davao Oriental
@@ -6080,9 +6080,9 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.2783203125,20.138470312451],[117.7294921875,13.068776734358],[114.9169921875,8.1027385777832],[117.9931640625,7.188100871179],[120.498046875,9.0153023334206],[119.443359375,3.9519408561576],[131.6162109375,6.4463177494577],[126.5625,21.983801417385],[120.2783203125,20.138470312451]]]}","Visayas, Mindanao",alert,actual,public,geo,immediate,severe,observed,2017-12-21 18:29:40,2017-12-21 18:00:00,2017-12-21 18:00:00,2017-12-21 23:00:00,2017-12-21 18:20:00,2017-12-21 18:20:00
 476,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #11
-For Severe Tropical Storm Vinta 
+For Severe Tropical Storm Vinta
 Issued 4am, Dec. 22, 2017","SWB #11
-For Severe Tropical Storm Vinta 
+For Severe Tropical Storm Vinta
 Issued 4am, Dec. 22, 2017
 
 Severe Tropical Storm into is now in the vicinity Boston, Davao Oriental area.
@@ -6105,20 +6105,20 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.7177734375,20.138470312451],[118.8720703125,15.411319377981],[117.0703125,9.4924081537655],[114.8291015625,7.0136679275666],[120.0146484375,8.4941045375519],[120.146484375,5.8783321096743],[124.7607421875,4.959615024698],[129.4189453125,7.3624668655358],[129.1552734375,18.895892559415],[120.7177734375,20.138470312451]]]}","Visayas, Mindanao, Bicol Region",alert,actual,public,geo,immediate,severe,observed,2017-12-21 21:39:34,2017-12-21 20:00:00,2017-12-21 20:00:00,2017-12-21 23:00:00,2017-12-21 21:29:54,2017-12-21 21:29:54
 477,165,0,PHL,en,General Notifications,"Severe Weather Bulletin #12
-For Severe Tropical Storm Vinta 
+For Severe Tropical Storm Vinta
 Issued at 8 AM, 22 Dec 2017 ","SWB #12
-For Severe Tropical Storm Vinta 
-Issued at 8 AM, 22 Dec 2017 
+For Severe Tropical Storm Vinta
+Issued at 8 AM, 22 Dec 2017
 
 Severe Tropical Storm ""VINTA"" is now traversing Compostela Valley.
 
-Scattered to widespread moderate to heavy rains will prevail over Visayas and Mindanao within 24 hours. 
+Scattered to widespread moderate to heavy rains will prevail over Visayas and Mindanao within 24 hours.
 
 Location: At 7 AM today, the center of Severe Tropical Storm ""VINTA"" was estimated at the vicinity of Laak, Compostela Valley
 
 Strength:	Max. sustained winds of 90 kph near the center and gustiness of up to 155 kph to move West at 20kph.
 
-Forecast Positions:	
+Forecast Positions:
 24 H (Tom. morning): 135 km N of Zamboanga City, Zamboanga del Sur
 48 H (Sun. morning):250 km SW of Puerto Princesa City, Palawan
 72 H (Mon. morning): 330 km SW of Pagasa Island, Palawan (Outside PAR)
@@ -6132,8 +6132,8 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.41015625,19.808054128089],[117.158203125,14.647368383897],[115.048828125,7.62388685312],[118.30078125,7.3624668655358],[121.6845703125,3.995780512963],[128.84765625,5.3972734076909],[128.935546875,15.538375926292],[127.08984375,20.179723502765],[120.41015625,19.808054128089]]]}",Visayas and Mindanao,alert,actual,public,geo,immediate,severe,observed,2017-12-22 00:52:12,2017-12-22 00:00:00,2017-12-22 00:00:00,2017-12-22 02:00:00,2017-12-22 00:42:31,2017-12-22 00:42:31
 478,165,0,PHL,en,Typhoon Warning,Severe Weather Bulletin # 16 as of 8PM,"Severe Weather Bulletin # 16
-For  Tropical Depression Vinta 
-Issued at 8 PM, 22 Dec 2017 
+For  Tropical Depression Vinta
+Issued at 8 PM, 22 Dec 2017
 
 TD ""VINTA"" is now over Zamboanga Sibugay and moving toward Sulu Sea.
 
@@ -6143,13 +6143,13 @@ Location: At 7 PM today, the center of TD ""VINTA"" was estimated at the vicinit
 
 Strength: Max. sustained winds of 60 kph near the center and gustiness of up to 90 kph to move West at 20kph.
 
-Forecast Positions:	
+Forecast Positions:
 24H(Tom.evening): 180 km SSW of Puerto Princesa City, Palawan
 48H(Sun.evening): 250 km S of Pagasa Island, Palawan (Outside PAR)
 72H(Mon.evening): 580 km WSW of Pagasa Island, Palawan (Outside PAR)
 
 Storm Warning Signal:
-Signal #1 
+Signal #1
 Luzon- Southern Palawan
 Visayas- Southern Negros Oriental and Siquijor
 Mindanao- Lanao del Norte, Misamis Occidental, Zamboanga del Norte, Zamboanga del Sur and Zamboanga-Sibugay
@@ -6211,7 +6211,7 @@ Issued 5 am, Dec 23, 2017
 
 VINTA has slightly intensified as it continues to track westward over the Sulu Sea
 
-Location: At 4:00 AM today, the center of Tropical Storm ""VINTA"" was est. at 165 km Northwest of Zamboanga City, Zamboanga del Sur 
+Location: At 4:00 AM today, the center of Tropical Storm ""VINTA"" was est. at 165 km Northwest of Zamboanga City, Zamboanga del Sur
 
 Strength: Max sustained winds of 75 kph near the center and gustiness of up to 90 kph to move at 20kph
 
@@ -6228,8 +6228,8 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.2451171875,20.138470312451],[117.7734375,13.752724664397],[117.0263671875,9.4924081537655],[116.279296875,8.1462428250344],[120.8935546875,7.4060477170763],[120.5419921875,5.5722498011139],[128.84765625,5.0033943450221],[126.650390625,16.003575733881],[121.2451171875,20.138470312451]]]}",Philippines ,alert,actual,public,geo,immediate,moderate,observed,2017-12-22 21:58:16,2017-12-22 21:00:00,2017-12-22 21:00:00,2017-12-23 00:00:00,2017-12-22 21:48:36,2017-12-22 21:48:36
 482,165,0,PHL,en,Typhoon Watch,SEVERE WEATHER BULLETIN #26,"SEVERE WEATHER BULLETIN #26
-For: STS Vinta 
-Issued at 2 AM, 24 Dec 2017 
+For: STS Vinta
+Issued at 2 AM, 24 Dec 2017
 
 Severe Tropical Storm ""Vinta"" Continues to Intensify After Crossing the Southern Portion of Balabac Island in Southern Palawan.
 
@@ -6238,7 +6238,7 @@ Location at 1 AM today, the center of STS ""VINTA"" was est. at 355 km Southwest
 Forecast Position:
 24H (Tonight): 325 km Southwest of Pagasa Island, Palawan (Outside PAR)
 
-Tropical Cyclone Warning Signal: 
+Tropical Cyclone Warning Signal:
 Signal No. 2- Southern Palawan
 Signal No. 1- Rest of Palawan
 
@@ -6247,9 +6247,9 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.70654296875,21.207458730483],[118.10302734375,17.161785912715],[116.806640625,12.082295837364],[116.30126953125,7.2534960500695],[120.2783203125,7.6892171277362],[122.62939453125,5.3316441534398],[128.86962890625,4.8939406089021],[129.44091796875,8.885071663469],[121.70654296875,21.207458730483]]]}",Philippines ,alert,actual,public,geo,immediate,moderate,observed,2017-12-23 18:57:45,2017-12-23 18:00:00,2017-12-23 18:00:00,2017-12-23 21:00:00,2017-12-23 18:48:11,2017-12-23 18:48:11
 483,165,0,PHL,en,Typhoon Watch,SEVERE WEATHER BULLETIN #27,"SEVERE WEATHER BULLETIN #27
 For TY Vinta
-Issued at 5 AM, 24 Dec. 2017 
+Issued at 5 AM, 24 Dec. 2017
 
-""Vinta"" Has Intensified into A Typhoon as It Approaches the Western Boundary of PAR. 
+""Vinta"" Has Intensified into A Typhoon as It Approaches the Western Boundary of PAR.
 Tropical Cyclone Warning Signal No. 1 over Northern Palawan has been lifted. Expected to exit the PAR between 5 AM and 8 AM today.
 
 Location at 4 AM today, the eye of Typhoon ""VINTA"" was located at 355 km South Southeast of Pagasa Island, Palawan. With max sustained winds of 120 kph near the center and gustiness of up to 145 kph. It is forecast to move West at 25 kph
@@ -6275,7 +6275,7 @@ Meanwhile, light to moderate rains to at times heavy rains over Marinduque, Cata
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[124.03015136719,11.469257905863],[124.37072753906,11.964097286893],[124.65087890625,13.838079936422],[123.92028808594,14.376155191012],[122.5634765625,14.626108798877],[121.89331054688,14.227113375215],[121.76696777344,13.362898869408],[122.42065429688,12.75823158407],[123.01940917969,12.474123690901],[124.03015136719,11.469257905863]]]}",Bicol Region,alert,actual,public,geo,immediate,moderate,observed,2017-12-27 02:59:18,2017-12-27 16:00:00,2017-12-26 16:00:00,2017-12-28 16:00:00,2017-12-27 02:49:41,2017-12-27 02:49:41
-485,165,0,PHL,en,General Notifications,Heavy Rainfall Warning due to Easterlies,"Heavy Rainfall Warning No. 2 
+485,165,0,PHL,en,General Notifications,Heavy Rainfall Warning due to Easterlies,"Heavy Rainfall Warning No. 2
 Weather System: Easterlies
 Issued at: 11:50 AM, 27 Dec 2017
 
@@ -6286,7 +6286,7 @@ Flooding is possible in low lying areas and landslide in mountainous areas.
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[125.9033203125,4.9377242743025],[127.50732421875,6.8391696263428],[127.2216796875,9.7956775828297],[126.14501953125,10.444597722835],[124.98046875,10.531020008465],[123.6181640625,9.2322487994187],[121.44287109375,8.2984702970674],[120.76171875,6.5118147063479],[119.50927734375,5.1347146340145],[119.86083984375,4.5435702793718],[122.54150390625,5.5285105256928],[123.57421875,6.4026484059639],[124.9365234375,5.069057826784],[125.9033203125,4.9377242743025]]]}",Mindanao Area,alert,actual,public,geo,immediate,moderate,observed,2017-12-27 04:07:43,2017-12-27 03:50:00,2017-12-27 03:50:00,2017-12-27 06:00:00,2017-12-27 03:58:04,2017-12-27 03:58:04
-486,165,0,PHL,en,General Notifications,Heavy Rainfall Warning,"Heavy Rainfall Warning # 2 
+486,165,0,PHL,en,General Notifications,Heavy Rainfall Warning,"Heavy Rainfall Warning # 2
 For: Tail End of a Cold Front
 Issued at: 3:30 PM, 27 Dec 2017
 
@@ -6322,34 +6322,34 @@ All are advised to monitor AOR, alert all volunteers, and report to OPCEN any un
 For Tropical Depression Agaton issued 5pm, Jan. 1, 2018","Severe Weather Bulletin #1
 For Tropical Depression Agaton issued 5pm, Jan. 1, 2018
 
-The LPA at ENE of Surgao City has developed into Tropical 
+The LPA at ENE of Surgao City has developed into Tropical
 Depression Agaton.
 
-Expected to make landfall over Caraga area tonight or 
+Expected to make landfall over Caraga area tonight or
 tomorrow early morning.
 
-Location of eye/center: At 4 PM today, the center of TD 
-Agaton was estimated at 175 km ENE of Hinatuan, Surigao del 
+Location of eye/center: At 4 PM today, the center of TD
+Agaton was estimated at 175 km ENE of Hinatuan, Surigao del
 Sur.
 
-Strength: Max. sustained winds of 45 kph near the center and 
+Strength: Max. sustained winds of 45 kph near the center and
 gustiness of up to 60 kph to move West at 19 kph
 
-Forecast Positions: 
-24 Hr (Tom, afternoon): 65 km East of Dipolog City, Zamboanga 
+Forecast Positions:
+24 Hr (Tom, afternoon): 65 km East of Dipolog City, Zamboanga
 del Norte
-48 Hr (Wed, afternoon):8 0 km SE of Puerto Princesa City, 
+48 Hr (Wed, afternoon):8 0 km SE of Puerto Princesa City,
 Palawan
-72 Hr (Thurs, afternoon): 90 km East of Pagasa Island, Palawan 
+72 Hr (Thurs, afternoon): 90 km East of Pagasa Island, Palawan
 (Outside PAR)
 
 Signal #1:
-Southern Leyte Surigao del Norte including Siargao Island, 
-Surigao del Sur, Dinagat Island, Agusan del Norte, Agusan del 
-Sur, Davao Oriental, Davao del Norte, Davao del Sur, North 
-Cotabato, Compostela Valley, Misamis Oriental, Misamis 
-Occidental, Lanao del Norte, Lanao del Sur, Camiguin, and 
-Bukidnon 
+Southern Leyte Surigao del Norte including Siargao Island,
+Surigao del Sur, Dinagat Island, Agusan del Norte, Agusan del
+Sur, Davao Oriental, Davao del Norte, Davao del Sur, North
+Cotabato, Compostela Valley, Misamis Oriental, Misamis
+Occidental, Lanao del Norte, Lanao del Sur, Camiguin, and
+Bukidnon
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -6361,13 +6361,13 @@ AGATON has slightly accelerated and is about to make landfall over Dinagat Islan
 
 Location as of 10 PM, the TD ""AGATON"" was at 80 km East of Surigao City, Surigao del Norte w/ max winds of 45 kph near the center and gustiness of up to 60 kph forecast to move at WNW at 22 kph
 
-Forecast Positions: 
+Forecast Positions:
 24H (Tom evening): 180 km South of Cuyo, Palawan
 48H (Wed evening):195 km East Southeast of Pagasa Island, Palawan
 72 Hour(Thurs evening): 285 km West of Pagasa Island, Palawan (Outside PAR)
 
 Warning Signal #1
-Visayas: Southern Leyte, Bohol, Southern Cebu, Siquijor, Southern Negros Oriental and Southern Negros Occidental, 
+Visayas: Southern Leyte, Bohol, Southern Cebu, Siquijor, Southern Negros Oriental and Southern Negros Occidental,
 
 Mindanao: Surigao del Norte including Siargao Island, Surigao del Sur, Dinagat Island, Agusan del Norte, Agusan del Sur, Davao del Norte, Compostela Valley, Misamis Oriental, Misamis Occidental, Lanao del Norte, Lanao del Sur, Camiguin, Bukidnon and Zamboanga del Norte
 
@@ -6381,13 +6381,13 @@ TD Agaton has made landfall over Dinagat Island province and Siargao Island area
 
 Location as of 1 AM, the TD ""AGATON"" was estimated to be in the vicinity of Socorro, Surigao del Norte w/ max winds of 55 kph near the center and gustiness of up to 90 kph forecast to move at WNW at 22 kph
 
-Forecast Positions: 
+Forecast Positions:
 24H (Tom eve): 155 km SSE of Cuyo, Palawan
 48H (Wed eve): 145 km ESE of Pagasa Island, Palawan
 72H (Thurs eve): 350 km West of Pagasa Island, Palawan (Outside PAR)
 
 TCWS #1
-Visayas: Palawan,Southern Leyte, Bohol, Southern Cebu, Siquijor, Southern Negros Oriental, Southern Negros Occidental, 
+Visayas: Palawan,Southern Leyte, Bohol, Southern Cebu, Siquijor, Southern Negros Oriental, Southern Negros Occidental,
 
 Mindanao: Surigao del Norte including Siargao Island, Surigao del Sur, Dinagat Island, Agusan del Norte, Misamis Oriental, Misamis Occidental, Lanao del Sur, Camiguin, Northern Bukidnon and Zamboanga del Norte
 ","{""type"":""Polygon"",""coordinates"":[[[125.15625,5.2660078828055],[126.67236328125,6.1842461612806],[126.7822265625,7.62388685312],[126.650390625,11.738302371437],[124.1455078125,15.029685756556],[123.0029296875,18.937464429642],[120.673828125,20.097206227084],[119.1357421875,16.214674588249],[119.4873046875,13.154376055419],[116.89453125,9.4924081537655],[115.9716796875,8.276727101164],[118.0810546875,7.7980785313553],[120.9814453125,10.660607953625],[121.46484375,8.276727101164],[119.00390625,5.5285105256928],[120.1904296875,4.1272853232454],[123.0908203125,6.8828002417676],[125.15625,5.2660078828055]]]}",Philippines,alert,actual,public,geo,immediate,moderate,observed,2018-01-01 18:20:02,2018-01-01 18:00:00,2018-01-01 18:00:00,2018-01-01 20:00:00,2018-01-01 18:10:31,2018-01-01 18:10:31
@@ -6425,9 +6425,9 @@ Issued at 11 AM, 2 Jan. 2018
 
 Agaton is now traversing Sulu sea and heading towards Palawan.
 
-Location of eye/center: At 10 AM today, the center of TD Agaton was est. at 170 km West of Dumaguete City, Negros Oriental. 
+Location of eye/center: At 10 AM today, the center of TD Agaton was est. at 170 km West of Dumaguete City, Negros Oriental.
 
-Strength: Max. winds of up to 55 kph near the center and gustiness of up to 90 kph to move West at 28 kph. 
+Strength: Max. winds of up to 55 kph near the center and gustiness of up to 90 kph to move West at 28 kph.
 
 Forecast Positions:
 • 24 Hr (Tom. morning): 275 km WNW of Puerto Princesa City or 265 km East of Pagasa Island, Palawan
@@ -6447,9 +6447,9 @@ Issued at 11 AM, 2 Jan. 2018
 
 Agaton is now traversing Sulu sea and heading towards Palawan.
 
-Location of eye/center: At 10 AM today, the center of TD Agaton was est. at 170 km West of Dumaguete City, Negros Oriental. 
+Location of eye/center: At 10 AM today, the center of TD Agaton was est. at 170 km West of Dumaguete City, Negros Oriental.
 
-Strength: Max. winds of up to 55 kph near the center and gustiness of up to 90 kph to move West at 28 kph. 
+Strength: Max. winds of up to 55 kph near the center and gustiness of up to 90 kph to move West at 28 kph.
 
 Forecast Positions:
 24 Hr (Tom. morning): 275 km WNW of Puerto Princesa City or 265 km East of Pagasa Island, Palawan
@@ -6477,8 +6477,8 @@ Location of eye/center: At 4 PM today, the center of TD AGATON was est. at 185 k
 
 Strength: Max. winds of up to 55 kph near the center and gustiness of up to 65 kph, to move West at 28 kph.
 
-Forecast Positions 
-24 Hr (Tom. afternoon): 530 km WNW of Puerto Princesa City, Palawan (OutsidePAR) 
+Forecast Positions
+24 Hr (Tom. afternoon): 530 km WNW of Puerto Princesa City, Palawan (OutsidePAR)
 
 Signal #: Palawan including Cuyo Island
 
@@ -6494,7 +6494,7 @@ Moderate to heavy rains are expected over the areas with Signal#1 as well as Bic
 
 Location as of 7:00 PM, the TD Agaton was at 105 km SE of Puerto Princesa City, Palawan w/ max winds of 55 kph near the center and gustiness of up to 65 kph moving 30 kph West
 
-Forecast Positions 
+Forecast Positions
 24H (Tom. afternoon): 645 km West Northwest of Puerto Princesa City, Palawan (Outside Par)
 
 TCWS #1: Palawan including Cuyo Island
@@ -6509,7 +6509,7 @@ Moderate to heavy rains are expected over the areas with TCWS#1 as well as Bicol
 
 Location as of 10 PM, the TD Agaton was at 40 km south of Puerto Princessa City, Palawan w/ max winds of 55 kph near the center and gustiness of up to 65 kph moving 30 kph West
 
-Forecast Positions 
+Forecast Positions
 24H (Tom. afternoon): 165 km West NE of Puerto Princesa City, Palawan (Outside PAR)
 
 TCWS #1: Palawan
@@ -6526,29 +6526,29 @@ Issued 11 AM, 03 Jan 2018
 
 Agaton has intensified into a tropical storm as it continues to move away from the country.
 
-Mod to heavy rains is expected over Bicol Region and the provinces of Rizal, Aurora and Quezon due to the Tail-end of a Cold Front. 
+Mod to heavy rains is expected over Bicol Region and the provinces of Rizal, Aurora and Quezon due to the Tail-end of a Cold Front.
 
 Sea travel is risky over the seaboards of N. Luzon and S. Luzon, eastern seaboard of C. Luzon, eastern and western seaboards of Visayas, and eastern seaboard of Mindanao due to the surge of NE Monsoon.
 
 Expected to exit the (PAR) this afternoon
 
-Location of eye/center: At 10 AM today, the center of Tropical Storm ""AGATON"" was est based on all available data at 390 km WNW of Puerto Princesa City, Palawan. 
+Location of eye/center: At 10 AM today, the center of Tropical Storm ""AGATON"" was est based on all available data at 390 km WNW of Puerto Princesa City, Palawan.
 
 Strength: w/ max winds of up to 65 kph near the center and gustiness of up to 80 kph.
 
-Forecast Positions 
+Forecast Positions
 24H (Tom morning):  310 km West of Pagasa Island, Palawan (OUTSIDE PAR)
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.9814453125,20.591652120829],[117.861328125,14.349547837185],[115.8837890625,10.919617760255],[114.873046875,7.9721977143869],[118.212890625,7.4496242601978],[120.5859375,7.7980785313553],[120.0146484375,5.9657536710655],[120.5419921875,4.1711154548674],[126.650390625,5.2660078828055],[128.49609375,7.2752923363722],[125.947265625,13.539200668931],[124.2333984375,17.644022027873],[120.9814453125,20.591652120829]]]}",Philippines ,alert,actual,public,geo,immediate,moderate,observed,2018-01-03 04:27:52,2018-01-03 03:00:00,2018-01-03 03:00:00,2018-01-03 09:00:00,2018-01-03 04:18:22,2018-01-03 04:18:22
-500,165,0,PHL,en,Typhoon Watch,Severe Weather Bulletin No. 14 - FINAL ,"Severe Weather Bulletin No. 14- FINAL 
+500,165,0,PHL,en,Typhoon Watch,Severe Weather Bulletin No. 14 - FINAL ,"Severe Weather Bulletin No. 14- FINAL
 For TS Agaton
 Issued 2 PM, 03 Jan 2018
 
 Tropical Storm Agaton is now outside (PAR).
 
-Mod to heavy rains is expected over Bicol Region and the provinces of Rizal, Aurora and Quezon due to the Tail-end of a Cold Front. 
+Mod to heavy rains is expected over Bicol Region and the provinces of Rizal, Aurora and Quezon due to the Tail-end of a Cold Front.
 
 Sea travel is risky over the seaboards of Northern Luzon and Southern Luzon, eastern seaboard of Central Luzon, eastern and western seaboards of Visayas, and eastern seaboard of Mindanao due to the surge of NE Monsoon.
 
@@ -6558,7 +6558,7 @@ Strength: w/ max winds of up to 65 kph near the center and gustiness of up to 80
 
 Forecast Movement: Forecast to move West at 25 kph
 
-Forecast Positions 
+Forecast Positions
 24H (Tom morning):  1,105 km WNW of Puerto Princesa City, Palawan (OUTSIDE PAR)
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
@@ -6570,7 +6570,7 @@ Due to Tail-end of Cold Front
 
 Yellow Warning: Cebu
 
-Flooding is possible in low-lying areas and landslides in mountainous areas. 
+Flooding is possible in low-lying areas and landslides in mountainous areas.
 
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -6604,7 +6604,7 @@ Issued at: 11 AM, 16 January 2018
 
 The Trough of LPA will bring moderate to heavy rains over Palawan, the whole of Visayas, and CARAGA while light to moderate rains will prevail over Northern Mindanao. The Tail-End of a Cold Front will bring light to moderate rains over the provinces of Albay, Sorsogon, Masbate, and Romblon.
 
-Resident in these areas must undertake precautionary measures against possible flash flood and landslides. 
+Resident in these areas must undertake precautionary measures against possible flash flood and landslides.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -6614,7 +6614,7 @@ Issued at 01:57 PM, January 16, 2018
 Weather System: Trough of LPA
 
 Orange warning level: Cebu, Bohol, Southern Leyte, Leyte
-Flooding is threatening in low-lying areas and landslides in mountainous areas. 
+Flooding is threatening in low-lying areas and landslides in mountainous areas.
 
 Yellow Warning Level: Negros Island, Siquijor
 Flooding is possible in low-lying areas and landslide in mountainous areas.
@@ -6625,20 +6625,20 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.2890625,20.2209
 507,165,0,PHL,en,General Notifications,PHIVOLCS Mayon Volcano Bulletin #16,"PHIVOLCS Mayon Volcano Bulletin #16
 Issued at 3:34 PM, 16 January 2018
 
-Alert Level 3 remains in effect over Mayon Volcano, which means that magma is at the crater and hazardous eruption is possible within weeks or even days. 
+Alert Level 3 remains in effect over Mayon Volcano, which means that magma is at the crater and hazardous eruption is possible within weeks or even days.
 
 The public is strongly advised to be vigilant and desist from entering the six (6) kilometer-radius Permanent Danger Zone (PDZ) and the 7-km Extended Danger Zone (EDZ) on the southern flanks due to the danger of rockfalls, landslides and sudden explosions or dome collapse that may generate hazardous volcanic flows.
 
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[123.73901367188,15.580710739162],[118.828125,14.604847155054],[116.13647460938,7.4496242601978],[118.99291992188,7.8089631205594],[121.80541992188,12.618897304044],[124.07958984375,11.469257905863],[124.9365234375,14.881087159091],[123.73901367188,15.580710739162]]]}",Southern Tagalog and Bicol Region ,alert,actual,public,geo,immediate,severe,observed,2018-01-16 07:43:22,2018-01-16 07:34:00,2018-01-16 07:34:00,2018-01-16 09:00:00,2018-01-16 07:34:19,2018-01-16 07:34:19
-508,165,0,PHL,en,General Notifications,PAGASA Heavy Rainfall Warning No. 4 ,"PAGASA Heavy Rainfall Warning No. 4 
+508,165,0,PHL,en,General Notifications,PAGASA Heavy Rainfall Warning No. 4 ,"PAGASA Heavy Rainfall Warning No. 4
 Weather System: Tail-end of a Cold Front
 Issued at 8 AM 17 January 2018
 
-Yellow Warning Level: Albay, Cam Sur, Cam Norte, Sorsogon, Catanduanes 
+Yellow Warning Level: Albay, Cam Sur, Cam Norte, Sorsogon, Catanduanes
 
-Flooding is possible in low lying areas and near river channels, landslides in mountainous 
+Flooding is possible in low lying areas and near river channels, landslides in mountainous
 areas.
 
 Meanwhile, light to moderate with at times heavy rains over Masbate (Ticao and Burias Island), Marinduque, Oriental Mindoro, Romblon and Northern Samar which may persist within 1 to 2 hours.
@@ -6647,9 +6647,9 @@ Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Lan
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.728515625,20.365227537412],[117.97119140625,16.23577209043],[117.0703125,10.768555807732],[115.751953125,7.1226962775183],[119.46533203125,7.4931964701223],[120.8935546875,8.2984702970674],[119.55322265625,4.631179340411],[123.57421875,5.3972734076909],[124.65087890625,4.631179340411],[127.3095703125,6.3808123319383],[126.650390625,15.644196600866],[121.728515625,20.365227537412]]]}",Philippines ,alert,actual,public,geo,immediate,moderate,observed,2018-01-17 01:14:45,2018-01-17 00:00:00,2018-01-17 00:00:00,2018-01-17 02:00:00,2018-01-17 01:05:27,2018-01-17 01:05:27
 509,165,0,PHL,en,General Notifications,PAGASA Weather Advisory No. 6,"PAGASA Weather Advisory No. 6
-Issued at 11 AM 17 January 2018 
+Issued at 11 AM 17 January 2018
 
-The tail-end of a cold front will bring moderate to heavy rains over Aurora, Quezon, and Bicol region while light to moderate rains will prevail over the rest of Central Luzon and Calabarzon, Metro Manila, and the provinces of Isabela, Quirino, Nueva Vizcaya, Pangasinan, Marinduque, Romblon, and Mindoro. the trough of an LPA will bring light to moderate rains over Eastern Visayas and Caraga. residents in these areas must undertake precautionary measures against possible flash floods and landslides. 
+The tail-end of a cold front will bring moderate to heavy rains over Aurora, Quezon, and Bicol subnational while light to moderate rains will prevail over the rest of Central Luzon and Calabarzon, Metro Manila, and the provinces of Isabela, Quirino, Nueva Vizcaya, Pangasinan, Marinduque, Romblon, and Mindoro. the trough of an LPA will bring light to moderate rains over Eastern Visayas and Caraga. residents in these areas must undertake precautionary measures against possible flash floods and landslides.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
 
@@ -6659,7 +6659,7 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.5087890625,20.4
 What: Fire Incident
 Where: Malanday, Marikina
 When: 2:55 pm, 17 January 2018
-Involved: residential 
+Involved: residential
 
 Status: now on 2nd alarm
 
@@ -6671,7 +6671,7 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[121.06933811679,14.
 What: Fire Incident
 Where: Malanday, Marikina
 When: 2:55 pm, 17 January 2018
-Involved: residential 
+Involved: residential
 
 Status: under control as of 3:16 pm
 
@@ -6738,7 +6738,7 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.27859389782,21.
 Weather System: LPA
 Issued at 04:33 PM, 24 Jan 2018
 
-Yellow warning: Biliran Island 
+Yellow warning: Biliran Island
 
 Flooding is possible in low-lying areas and landslides in mountainous areas.
 
@@ -6819,7 +6819,7 @@ For: Tail-End of A Cold Front
 ","Weather Advisory #2 as of 11 AM, Jan. 28, 2018
 For: Tail-End of A Cold Front
 
-The Tail-End of A Cold Front will continue to bring moderate to occasionally heavy rains and thunderstorms over Surigao Del Norte, Dinagat Province, Bicol Region and the Visayas. 
+The Tail-End of A Cold Front will continue to bring moderate to occasionally heavy rains and thunderstorms over Surigao Del Norte, Dinagat Province, Bicol Region and the Visayas.
 
 Residents in these areas must undertake precautionary measures against possible flash floods and landslides.
 
@@ -6832,7 +6832,7 @@ For: Tail-End of the Cold Front
 ",alert,actual,public,geo,immediate,extreme,observed,2018-01-28 03:14:05,2018-01-28 03:00:00,2018-01-28 03:00:00,2018-01-28 06:00:00,2018-01-28 03:05:08,2018-01-28 03:05:08
 524,165,0,PHL,en,General Notifications,"Weather Advisory# 3 FINAL as of 11 AM, Jan. 29, 2018
 For Tail-End of A Cold Front ","Weather Advisory# 3 FINAL as of 11 AM, Jan. 29, 2018
-For Tail-End of A Cold Front 
+For Tail-End of A Cold Front
 
 The effect of the Tail-End of A Cold Front has weakened. Improved weather conditions will be experienced over the Visayas And the Regions of Bicol and CARAGA. However, isolated rain showers or thunderstorms, especially during the afternoon or evening, should be expected in these areas due to the Easterlies.
 
@@ -6844,17 +6844,17 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[116.3232421875,14.9
 For Tail-End of A Cold Front ",alert,actual,public,geo,immediate,extreme,observed,2018-01-29 04:37:49,2018-01-29 03:00:00,2018-01-29 03:00:00,2018-01-29 06:00:00,2018-01-29 04:28:47,2018-01-29 04:28:47
 525,96,0,NZL,en,General Notifications,West Coast Civil Defence Emergency Management Group has been advised that this is potentially significant weather event and could have a significant impact on some Communities. ,"[CDWC] West Coast Civil Defence Emergency Management Group has been advised that this is a potentially significant weather event and the combination of Rain, Wind and Storm Surge could have a significant impact on some Communities.
 
-This may cause streams and rivers to rise rapidly. Surface flooding, slips and coastal inundation are also possible and driving conditions may be hazardous. We will keep you updated with any changes as this weather system develops. We strongly advised to keep up to date with the latest forecasts and warnings. 
+This may cause streams and rivers to rise rapidly. Surface flooding, slips and coastal inundation are also possible and driving conditions may be hazardous. We will keep you updated with any changes as this weather system develops. We strongly advised to keep up to date with the latest forecasts and warnings.
 
 For further information see https://westcoastemergency.govt.nz/","{""type"":""Polygon"",""coordinates"":[[[172.24365234375,-40.81380923057],[172.68310546875,-41.228249015185],[172.0458984375,-41.828642001861],[172.41943359375,-42.29356419217],[171.59545898438,-42.884014670443],[170.58471679688,-43.413028684751],[169.68383789062,-43.984910114047],[169.07958984375,-44.1270280065],[168.3984375,-44.512176171071],[168.05786132812,-44.268804788566],[172.24365234375,-40.81380923057]]]}",West Coast,alert,actual,public,geo,immediate,extreme,observed,2018-01-31 02:35:54,2018-01-31 02:35:00,2018-01-31 02:35:00,2018-01-31 09:00:00,2018-01-31 02:26:59,2018-01-31 02:26:59
 526,165,0,PHL,en,General Notifications,PAGASA Heavy Rainfall Warning No.1,"PAGASA Heavy Rainfall Warning No.1
-Weather System: Trough of a LPA 
+Weather System: Trough of a LPA
 Issued at 10:44 AM, 05 February 2018
 
 Yellow: Eastern Samar, Southern portions of Samar
 - Flooding is possible in low lying areas and landslides in mountainous areas.
 
-Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- 
+Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline-
 
 (02) 790 2300
 
@@ -6985,14 +6985,14 @@ Location: At 4PM today, the center of TS  ""SANBA"" was at 1,035 km East of Hina
 
 Strength: Max sustained winds of 65 kph near the center and gustiness of up to 80 kph moving WNW at 27 kph
 
-Forecast Positions:	
+Forecast Positions:
 24H (Tom afternoon): 430 km East of Hinatuan, Surigao del Sur
 48H (Tue afternoon): 50 km West of Butuan City, Agusan del Norte
 72H (Wed afternoon): 265 km ESE of Puerto Princesa City, Palawan
 96H (Thursday afternoon): 195 km WNW of Puerto Princesa City, Palawan
 120H (Friday afternoon): 80 km ENE of Pagasa Island, Palawan
 
-TCWS #1 (30-60kph expected in 36hrs) 
+TCWS #1 (30-60kph expected in 36hrs)
 Dinagat Islands, Surigao del Norte, Surigao del Sur, and Davao Oriental
 
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
@@ -7002,17 +7002,17 @@ OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[120.9375,21.6574281
 
 The Tropical Storm outside PAR has entered PAR and was named ""BASYANG"".
 
-Scattered to widespread moderate to heavy rains will prevail over the Eastern Section of Visayas and Mindanao beginning tomorrow. 
+Scattered to widespread moderate to heavy rains will prevail over the Eastern Section of Visayas and Mindanao beginning tomorrow.
 
 Expected to make landfall in CARAGA Region on Tuesday morning (Feb. 13).
 
-Location: at 10 pm today, the center of Tropical Storm ""BASYANG"" was at 870 km East of Hinatuan, Surigao Del Sur. 
+Location: at 10 pm today, the center of Tropical Storm ""BASYANG"" was at 870 km East of Hinatuan, Surigao Del Sur.
 
 Strength: Max sustained winds of up to 65 kph near the center and gustiness of up to 80 kph.
 
 Movement: West Northwest at 27 kph.
 
-Positions: 
+Positions:
 24 hour (Tomorrow evening): 265 km East of Hinatuan, Surigao Del Sur.
 
 48 hour (Tuesday evening): 35 km SE of Dumaguete City, Negros Oriental
@@ -7047,7 +7047,7 @@ Movement: WNW at 25 kph.
 Positions:
 24 hour (Tomorrow morning): 115 km ENE of Hinatuan, Surigao Del Sur
 48 hour (Wednesday morning): 60 km WSW of Dumaguete City, Negros Oriental
-72 hour (Thursday morning): 65 km WNW of Puerto Princesa City, Palawan 
+72 hour (Thursday morning): 65 km WNW of Puerto Princesa City, Palawan
 96 hour (Friday morning): 95 km NE of PAGASA Is., Palawan (Outside PAR)
 120 hour (Saturday morning): 160 km NW of PAGASA Is., Palawan (Outside PAR)
 
@@ -7069,7 +7069,7 @@ Movement: WNW at 25 kph
 Positions:
 24 hour (Tomorrow morning): 120 km ENE of Hinatuan, Surigao Del Sur
 48 hour (Wednesday morning): 155 km W of Dumaguete City, Negros Oriental
-72 hour (Thursday morning): 140 km WNW of Puerto Princesa City, Palawan 
+72 hour (Thursday morning): 140 km WNW of Puerto Princesa City, Palawan
 96 hour (Friday morning): 105 km N of PAGASA Is., Palawan (Outside PAR)
 120 hour (Saturday morning): 315 km NW of PAGASA Is., Palawan (Outside PAR)
 
@@ -7079,7 +7079,7 @@ TCWS#1- So. Leyte, Bohol, Cebu, Siquijor, CARAGA, Camiguin, Compostela Valley, D
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02)790 2300
 
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[116.71875,14.944784875088],[121.7724609375,21.861498734373],[131.0009765625,6.6646075621726],[122.0361328125,4.6968790268714],[113.5546875,11.221510260011],[116.71875,14.944784875088]]]}","Severe Weather Bulletin #4 as of 8 AM, Feb. 12, 2018",alert,actual,public,geo,immediate,extreme,observed,2018-02-12 00:26:08,2018-02-12 00:00:00,2018-02-12 00:00:00,2018-02-12 03:00:00,2018-02-12 00:17:03,2018-02-12 00:17:03
-540,165,0,PHL,en,General Notifications,PAGASA Heavy Rainfall Warning No. 3 for Mindanao,"PAGASA Heavy Rainfall Warning No. 3 for Mindanao 
+540,165,0,PHL,en,General Notifications,PAGASA Heavy Rainfall Warning No. 3 for Mindanao,"PAGASA Heavy Rainfall Warning No. 3 for Mindanao
 Weather System: TS Basyang
 Issued at 10:45 AM 12 Feb 2018‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬
 
@@ -7100,14 +7100,14 @@ Strength: Max sustained winds of 65 kph near the center and gustiness of up to 8
 
 Forecast to move WNW at 22 kph.
 
-Positions: 
+Positions:
 24H (Tom morning): 55 km East of Hinatuan, Surigao del Sur
 48H (Wed morning):160 km West Southwest of Dumaguete City, Negros Oriental
 72H (Thurs morning):145 km West Northwest of Puerto Princesa City, Palawan
 96H (Fri morning):50 km Northwest of Pagasa Island, Palawan (OUTSIDE PAR)
 
 TCWS#2- Surigao del Sur
-TCWS#1- Dinagat Islands, Surigao del Norte, Agusan del Norte, Agusan del Sur, Camiguin, Compostela Valley, 
+TCWS#1- Dinagat Islands, Surigao del Norte, Agusan del Norte, Agusan del Sur, Camiguin, Compostela Valley,
 Davao Oriental, Davao del Norte, Misamis Oriental, Misamis Occidental, Lanao del Norte, Lanao del Sur, Bukidnon, and northern portion of Zamboanga del Norte
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02) 790 2300
@@ -7118,7 +7118,7 @@ Issued at: 1:30 PM, 12 Feb. 2018‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬
 
 Yellow Warning: Dinagat Islands, Surigao del Norte, Surigao del Sur, Agusan del Norte, Agusan del Sur, Davao Oriental, Compostela Valley, Davao del Norte, Davao City
 
-Flooding is possible. Flooding in low-lying areas especially along river channels. 
+Flooding is possible. Flooding in low-lying areas especially along river channels.
 
 While light to moderate rains, especially affecting portions of Misamis Oriental, North Cotabato, Davao del Sur, Lanao del Sur, Sultan Kudarat, South Cotabato, Sarangani and nearby areas.
 
@@ -7140,7 +7140,7 @@ Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; La
 OPERATIONS CENTER","{""type"":""Polygon"",""coordinates"":[[[125.25512695312,9.8389793755793],[126.02416992188,10.087853819146],[126.00219726562,11.383109216353],[125.44189453125,12.801088279674],[124.61791992188,12.811801316583],[124.0576171875,12.640338306847],[123.95874023438,11.953349393643],[123.93676757812,11.146066375907],[124.35424804688,10.347343930125],[125.04638671875,9.6007499322469],[125.25512695312,9.8389793755793]]]}",Visayas,alert,actual,public,geo,immediate,moderate,observed,2018-02-12 07:01:37,2018-02-12 05:40:00,2018-02-12 05:40:00,2018-02-12 07:40:00,2018-02-12 06:53:03,2018-02-12 06:53:03
 544,165,0,PHL,en,Tropical Storm Warning,Severe Weather Bulletin #6 for TS Basyang,"PAGASA Severe Weather Bulletin #6 as of 2 PM, Feb. 12, 2018
 
-""BASYANG"" has maintained its strength as it continues to approach the Eastern seaboard of Mindanao and it's expected to make landfall in CARAGA region tomorrow morning or afternoon (Feb 13)
+""BASYANG"" has maintained its strength as it continues to approach the Eastern seaboard of Mindanao and it's expected to make landfall in CARAGA subnational tomorrow morning or afternoon (Feb 13)
 
 Loc: 1 PM today, the center of TS ""BASYANG"" was estimated at 570 km ESE of Hinatuan, Surigao del Sur
 
@@ -7148,7 +7148,7 @@ Strength: Max winds of 65 kph near the center and gustiness of up to 80 kph
 
 Forecast to move WNW at 22 kph.
 
-Positions: 
+Positions:
 24 H (Tom morning): 55 km East of Hinatuan, Surigao del Sur
 48 H (Wed morning):165 km WSW of Dumaguete City, Negros Oriental
 72 H (Thurs morning): 135 km WNW of Puerto Princesa City, Palawan
@@ -7166,7 +7166,7 @@ Issued at: 4:40 PM, 12 Feb. 2018‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬
 
 Yellow Warning: ‪Camiguin, Misamis Oriental, Bukidnon, Lanao del Norte, Lanao del Sur, Dinagat Islands, Surigao del Norte, Surigao del Sur, Agusan del Norte, Agusan del Sur, Compostela Valley, Davao City, Davao Oriental, Davao Occidental, Davao del Norte, Davao del Sur, Maguindanao, South Cotabato, North Cotabato, SultanKudarat.
 
-Flooding is possible. Flooding in low-lying areas especially along river channels. 
+Flooding is possible. Flooding in low-lying areas especially along river channels.
 
 Meanwhile, Light to moderate rains affecting Zamboanga City, Zamboanga del Norte, Zamboanga del Sur, Zamboanga Sibugay, Misamis Occidental, and Sarangani.
 
@@ -7179,9 +7179,9 @@ Issued at: 4:38 PM, 12 Feb. 2018‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬‬
 
 Yellow Warning: Cebu, Bohol, Siquijor
 
-Flooding is possible. Flooding in low-lying areas especially along 
+Flooding is possible. Flooding in low-lying areas especially along
 
-river channels. 
+river channels.
 
 
 Kindly monitor and report any untoward incidents to PRC OPCEN at 09188076734; Landline- (02) 790 2300
@@ -7271,7 +7271,7 @@ Weather System: TS BASYANG
 
 Orange: Panay Island, Guimaras
 
-Flooding is threatening in low lying areas and landslides in mountainous areas. 
+Flooding is threatening in low lying areas and landslides in mountainous areas.
 
 Kindly monitor and report any untoward incident to PRC OPCEN at 09188076734; Landline- (02)790 2300
 
@@ -7287,7 +7287,7 @@ Strength: Maximum sustained winds of 65 kph near the center and gustiness of up 
 
 Movement: WNW at 25 kph
 
-Positions: 
+Positions:
 24 Hour (Tomorrow morning): 115 km West of Dumaguete City, Negros Oriental.
 
 48 Hour (Thursday morning):125 km West of Puerto Princesa City, Palawan.

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,12 +42,12 @@ Route::group([
     'middleware' => 'BasicAuth',
     'prefix' => 'v1',
 ], function () {
-    Route::get('/regions/{country_code}', 'RegionController@getAllForOrganisation');
-    Route::get('/regions/{country_code}/{code}', 'RegionController@getForCountryCode');
-    Route::post('/regions', 'RegionController@createRegion');
-    Route::put('/regions/region/{regionId}', 'RegionController@updateRegion');
-    Route::delete('/regions/region/{regionId}', 'RegionController@deleteRegion');
-    Route::delete('/regions/region/translation/{translationId}', 'RegionController@deleteTranslation');
+    Route::get('/subnationals/{country_code}', 'RegionController@getAllForOrganisation');
+    Route::get('/subnationals/{country_code}/{code}', 'RegionController@getForCountryCode');
+    Route::post('/subnationals', 'RegionController@createRegion');
+    Route::put('/subnationals/subnational/{regionId}', 'RegionController@updateRegion');
+    Route::delete('/subnationals/subnational/{regionId}', 'RegionController@deleteRegion');
+    Route::delete('/subnationals/subnational/translation/{translationId}', 'RegionController@deleteTranslation');
 
     // Alert management
     Route::post('alerts', 'AlertController@post');
@@ -72,7 +72,7 @@ Route::group([
 
     // "What Now" API endpoints
     Route::get('org/{code}/whatnow/revisions/latest', 'WhatNowController@getLatestForCountryCode');
-    Route::get('org/{code}/{region}/whatnow/revisions/latest', 'WhatNowController@getLatestForRegion');
+    Route::get('org/{code}/{subnational}/whatnow/revisions/latest', 'WhatNowController@getLatestForRegion');
     Route::get('whatnow/{id}/revisions/latest', 'WhatNowController@getLatestById');
     Route::put('whatnow/{id}', 'WhatNowController@putById');
     Route::post('whatnow', 'WhatNowController@post');

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -480,12 +480,12 @@
                 }
             }
         },
-        "/regions": {
+        "/subnationals": {
             "post": {
                 "tags": [
                     "Regions"
                 ],
-                "summary": "Create a new region",
+                "summary": "Create a new subnational",
                 "operationId": "createRegion",
                 "requestBody": {
                     "required": true,
@@ -503,12 +503,12 @@
                                         "example": "USA"
                                     },
                                     "title": {
-                                        "description": "Title of the region",
+                                        "description": "Title of the subnational",
                                         "type": "string",
                                         "example": "North America"
                                     },
                                     "slug": {
-                                        "description": "Slug for the region (optional)",
+                                        "description": "Slug for the subnational (optional)",
                                         "type": "string",
                                         "example": "north-america"
                                     },
@@ -535,7 +535,7 @@
                                                 "description": {
                                                     "description": "Description in the specified language",
                                                     "type": "string",
-                                                    "example": "Description of the region"
+                                                    "example": "Description of the subnational"
                                                 }
                                             },
                                             "type": "object"
@@ -569,18 +569,18 @@
                 }
             }
         },
-        "/regions/region/{regionId}": {
+        "/subnationals/subnational/{regionId}": {
             "put": {
                 "tags": [
                     "Regions"
                 ],
-                "summary": "Update an existing region",
+                "summary": "Update an existing subnational",
                 "operationId": "updateRegion",
                 "parameters": [
                     {
                         "name": "regionId",
                         "in": "path",
-                        "description": "ID of the region to update",
+                        "description": "ID of the subnational to update",
                         "required": true,
                         "schema": {
                             "type": "integer",
@@ -595,14 +595,14 @@
                             "schema": {
                                 "properties": {
                                     "title": {
-                                        "description": "Updated title of the region (optional)",
+                                        "description": "Updated title of the subnational (optional)",
                                         "type": "string",
                                         "example": "Updated Region Title"
                                     },
                                     "slug": {
-                                        "description": "Updated slug for the region (optional)",
+                                        "description": "Updated slug for the subnational (optional)",
                                         "type": "string",
-                                        "example": "updated-region-slug"
+                                        "example": "updated-subnational-slug"
                                     },
                                     "translations": {
                                         "type": "array",
@@ -664,13 +664,13 @@
                 "tags": [
                     "Regions"
                 ],
-                "summary": "Delete a region",
+                "summary": "Delete a subnational",
                 "operationId": "deleteRegion",
                 "parameters": [
                     {
                         "name": "regionId",
                         "in": "path",
-                        "description": "ID of the region to delete",
+                        "description": "ID of the subnational to delete",
                         "required": true,
                         "schema": {
                             "type": "integer",
@@ -700,12 +700,12 @@
                 }
             }
         },
-        "/regions/{country_code}": {
+        "/subnationals/{country_code}": {
             "get": {
                 "tags": [
                     "Regions"
                 ],
-                "summary": "Get all regions for a specific organisation by country code",
+                "summary": "Get all subnationals for a specific organisation by country code",
                 "operationId": "d2296fe4eb4c2d71309b7bd2370494bd",
                 "parameters": [
                     {
@@ -737,12 +737,12 @@
                 }
             }
         },
-        "/regions/{country_code}/{code}": {
+        "/subnationals/{country_code}/{code}": {
             "get": {
                 "tags": [
                     "Regions"
                 ],
-                "summary": "Get regions for a specific organisation by country code and language code",
+                "summary": "Get subnationals for a specific organisation by country code and language code",
                 "operationId": "e80be67aaefaf2057958c0e54908fbc9",
                 "parameters": [
                     {
@@ -786,12 +786,12 @@
                 }
             }
         },
-        "/regions/region/translation/{translationId}": {
+        "/subnationals/subnational/translation/{translationId}": {
             "delete": {
                 "tags": [
                     "Regions"
                 ],
-                "summary": "Delete a region translation",
+                "summary": "Delete a subnational translation",
                 "operationId": "deleteTranslation",
                 "parameters": [
                     {
@@ -998,9 +998,9 @@
                         }
                     },
                     {
-                        "name": "region",
+                        "name": "subnational",
                         "in": "query",
-                        "description": "Filter by region ID",
+                        "description": "Filter by subnational ID",
                         "required": false,
                         "schema": {
                             "type": "integer"
@@ -1143,7 +1143,7 @@
                                         "example": "Flood"
                                     },
                                     "regionName": {
-                                        "description": "Name of the region (optional)",
+                                        "description": "Name of the subnational (optional)",
                                         "type": "string",
                                         "example": "North Region"
                                     },
@@ -1301,9 +1301,9 @@
                         }
                     },
                     {
-                        "name": "region",
+                        "name": "subnational",
                         "in": "query",
-                        "description": "Filter by region slug",
+                        "description": "Filter by subnational slug",
                         "required": false,
                         "schema": {
                             "type": "string"
@@ -1395,12 +1395,12 @@
                 }
             }
         },
-        "/org/{code}/{region}/whatnow/revisions/latest": {
+        "/org/{code}/{subnational}/whatnow/revisions/latest": {
             "get": {
                 "tags": [
                     "Whatnow"
                 ],
-                "summary": "Get the latest revisions for a specific region",
+                "summary": "Get the latest revisions for a specific subnational",
                 "operationId": "getLatestForRegion",
                 "parameters": [
                     {
@@ -1413,7 +1413,7 @@
                         }
                     },
                     {
-                        "name": "region",
+                        "name": "subnational",
                         "in": "path",
                         "description": "Region slug to fetch the latest revisions for",
                         "required": true,
@@ -1473,7 +1473,7 @@
                                         "example": "Flood"
                                     },
                                     "regionName": {
-                                        "description": "Name of the region (optional)",
+                                        "description": "Name of the subnational (optional)",
                                         "type": "string",
                                         "example": "North Region"
                                     },

--- a/tests/Feature/RegionTest.php
+++ b/tests/Feature/RegionTest.php
@@ -23,7 +23,7 @@ class RegionTest extends TestCase
             'org_id' => $this->organisation->id,
         ]);
 
-        $this->delete('DELETE FROM regions');
+        $this->delete('DELETE FROM subnationals');
 
         $this->delete('DELETE FROM region_translations');
     }
@@ -33,7 +33,7 @@ class RegionTest extends TestCase
         $data = [
             'countryCode' => $this->organisation->country_code,
             'title' => 'Test Region 1',
-            'slug' => 'test-region-1',
+            'slug' => 'test-subnational-1',
             'translations' => [
                 'en' => [
                     'title' => 'Testing 1',
@@ -46,7 +46,7 @@ class RegionTest extends TestCase
             ],
         ];
 
-        $response = $this->json('POST', '/v1/regions', $data);
+        $response = $this->json('POST', '/v1/subnationals', $data);
 
         //dd($response);
 
@@ -55,10 +55,10 @@ class RegionTest extends TestCase
 
     public function testUpdateRegion()
     {
-        $region = $this->organisation->regions()->create([
+        $region = $this->organisation->subnationals()->create([
             'countryCode' => $this->organisation->country_code,
             'title' => 'Test Region',
-            'slug' => 'test-region',
+            'slug' => 'test-subnational',
             'translations' => [
                 'en' => [
                     'title' => 'Testing 1',
@@ -74,7 +74,7 @@ class RegionTest extends TestCase
         $data = [
             'countryCode' => $this->organisation->country_code,
             'title' => 'Test Region 1',
-            'slug' => 'test-region-1',
+            'slug' => 'test-subnational-1',
             'translations' => [
                 'en' => [
                     'title' => 'Testing 2',
@@ -98,7 +98,7 @@ class RegionTest extends TestCase
 
         $this->assertEquals(0, $matched);
 
-        $this->json('PUT', "/v1/regions/region/{$region->id}", $data)
+        $this->json('PUT', "/v1/subnationals/subnational/{$region->id}", $data)
             ->assertStatus(201);
 
         $matched = RegionTranslation::where('region_id', '=', $region->id)
@@ -111,22 +111,22 @@ class RegionTest extends TestCase
 
     public function testGetRegionsForOrganisation()
     {
-        $this->json('GET', '/v1/regions/USA')
+        $this->json('GET', '/v1/subnationals/USA')
             ->assertStatus(200);
     }
 
     public function testGetLaguageSpecificRegionsForOrganisation()
     {
-        $this->json('GET', '/v1/regions/USA/es')
+        $this->json('GET', '/v1/subnationals/USA/es')
             ->assertStatus(200);
     }
 
     public function testDeleteRegionForOrganisation()
     {
-        $region = $this->organisation->regions()->create([
+        $region = $this->organisation->subnationals()->create([
             'countryCode' => $this->organisation->country_code,
             'title' => 'Test Region',
-            'slug' => 'test-region',
+            'slug' => 'test-subnational',
             'translations' => [
                 'en' => [
                     'title' => 'Testing 1',
@@ -139,7 +139,7 @@ class RegionTest extends TestCase
             ],
         ]);
 
-        $this->json('DELETE', "/v1/regions/region/{$region->id}")
+        $this->json('DELETE', "/v1/subnationals/subnational/{$region->id}")
             ->assertStatus(202);
     }
 }


### PR DESCRIPTION
Summary:
Change “region” to “subnational” and decouple translations from region_translations.

Description:
The following changes were implemented to improve clarity and translation management:

Terminology Update:

The suffix "region" was replaced with "subnational" to prevent confusion, as "region" was being used for different entities within the system.

Decoupling Translations from region_translations:

Previously, translations were dependent on the region_translations table, which was not properly updating with the frontend.

Now, message translations no longer rely directly on the region’s language, ensuring better flexibility and synchronization.

Acceptance Criteria:
"region" suffix is fully replaced with "subnational" in the system.

Translations no longer depend on region_translations.

Messages update correctly in the frontend.