### PR TITLE
WN-280

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -66,6 +66,8 @@ class ApplicationController extends Controller
      *     tags={"Applications"},
      *     summary="Get all applications for a user",
      *     operationId="getAllForUser",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="userId",
      *         in="query",
@@ -121,6 +123,8 @@ class ApplicationController extends Controller
      *     tags={"Applications"},
      *     summary="Get an application by ID",
      *     operationId="getApplicationById",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="id",
      *         in="path",
@@ -177,6 +181,8 @@ class ApplicationController extends Controller
      *     tags={"Applications"},
      *     summary="Create a new application",
      *     operationId="createApplication",
+     *     security={},
+     *     deprecated=true,
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
@@ -236,6 +242,8 @@ class ApplicationController extends Controller
      *     tags={"Applications"},
      *     summary="Update an application by ID",
      *     operationId="updateApplication",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="id",
      *         in="path",
@@ -294,6 +302,8 @@ class ApplicationController extends Controller
      *     tags={"Applications"},
      *     summary="Delete an application by ID",
      *     operationId="deleteApplication",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="id",
      *         in="path",

--- a/app/Http/Controllers/FileUploadController.php
+++ b/app/Http/Controllers/FileUploadController.php
@@ -19,6 +19,8 @@ class FileUploadController extends Controller
      *     tags={"Whatnow"},
      *     summary="Upload a file",
      *     operationId="uploadFile",
+     *     security={},
+     *     deprecated=true,
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\MediaType(

--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -51,7 +51,7 @@ class OrganisationController extends Controller
     /**
      * @OA\Get(
      *     path="/org",
-     *     summary="Get all organisations",
+     *     summary="Get all organisations (public)",
      *     security={{"ApiKeyAuth": {}}},
      *     tags={"Organisation"},
      *     @OA\Response(
@@ -99,7 +99,7 @@ class OrganisationController extends Controller
         /**
      * @OA\Get(
      *     path="/org/{code}",
-     *     summary="Get organisation by country code",
+     *     summary="Get organisation by country code (public)",
      *     tags={"Organisation"},
      *     security={{"ApiKeyAuth": {}}},
      *     @OA\Parameter(
@@ -152,6 +152,8 @@ class OrganisationController extends Controller
      *     path="/org/{code}",
      *     tags={"Organisation"},
      *     summary="Update an organisation by its country code",
+     *     security={},
+     *     deprecated=true,
      *     description="Updates the details of an organisation based on the provided country code.",
      *     operationId="OrganisationController@putById",
      *     @OA\Parameter(

--- a/app/Http/Controllers/RegionController.php
+++ b/app/Http/Controllers/RegionController.php
@@ -43,6 +43,8 @@ class RegionController extends Controller
      *     tags={"Regions"},
      *     summary="Create a new region",
      *     operationId="createRegion",
+     *     security={},
+     *     deprecated=true,
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
@@ -132,6 +134,8 @@ class RegionController extends Controller
      *     tags={"Regions"},
      *     summary="Update an existing region",
      *     operationId="updateRegion",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="regionId",
      *         in="path",
@@ -219,6 +223,8 @@ class RegionController extends Controller
      *     path="/regions/{country_code}",
      *     summary="Get all regions for a specific organisation by country code",
      *     tags={"Regions"},
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="country_code",
      *         in="path",
@@ -273,6 +279,8 @@ class RegionController extends Controller
      *     path="/regions/{country_code}/{code}",
      *     summary="Get regions for a specific organisation by country code and language code",
      *     tags={"Regions"},
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="country_code",
      *         in="path",
@@ -333,6 +341,8 @@ class RegionController extends Controller
      *     tags={"Regions"},
      *     summary="Delete a region",
      *     operationId="deleteRegion",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="regionId",
      *         in="path",
@@ -372,6 +382,8 @@ class RegionController extends Controller
      *     tags={"Regions"},
      *     summary="Delete a region translation",
      *     operationId="deleteTranslation",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="translationId",
      *         in="path",

--- a/app/Http/Controllers/UsageLogController.php
+++ b/app/Http/Controllers/UsageLogController.php
@@ -52,6 +52,8 @@ class UsageLogController extends Controller
      *     tags={"UsageLogs"},
      *     summary="Get application usage logs",
      *     operationId="getApplicationLogs",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="fromDate",
      *         in="query",
@@ -126,6 +128,8 @@ class UsageLogController extends Controller
      *     tags={"UsageLogs"},
      *     summary="Get endpoint usage logs",
      *     operationId="getEndpointLogs",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="fromDate",
      *         in="query",
@@ -198,6 +202,8 @@ class UsageLogController extends Controller
      *     tags={"UsageLogs"},
      *     summary="Export usage logs as CSV",
      *     operationId="exportUsageLogs",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="fromDate",
      *         in="query",
@@ -306,6 +312,8 @@ class UsageLogController extends Controller
      *     tags={"UsageLogs"},
      *     summary="Get usage log totals",
      *     operationId="getTotals",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="society",
      *         in="query",

--- a/app/Http/Controllers/WhatNowController.php
+++ b/app/Http/Controllers/WhatNowController.php
@@ -93,7 +93,7 @@ class WhatNowController extends Controller
      * @OA\Get(
      *     path="/whatnow/{id}",
      *     tags={"Whatnow"},
-     *     summary="Obtiene un recurso publicado por ID",
+     *     summary="Obtiene un recurso publicado por ID (public)",
      *     description="Retorna los detalles de un recurso publicado basado en el ID proporcionado.",
      *     operationId="getPublishedById",
      *     security={{"ApiKeyAuth": {}}},
@@ -159,6 +159,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Get the latest revision of a WhatNow entity by ID",
      *     operationId="getLatestById",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="id",
      *         in="path",
@@ -214,6 +216,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Delete a WhatNow entity by ID",
      *     operationId="deleteById",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="id",
      *         in="path",
@@ -260,7 +264,7 @@ class WhatNowController extends Controller
      * @OA\Get(
      *     path="/org/{code}/whatnow",
      *     tags={"Whatnow"},
-     *     summary="Get a feed of WhatNow entities for a specific organisation",
+     *     summary="Get a feed of WhatNow entities for a specific organisation (public)",
      *     operationId="getFeed",
      *     security={{"ApiKeyAuth": {}}},
      *     @OA\Parameter(
@@ -364,6 +368,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Get the latest revisions for a country code",
      *     operationId="getLatestForCountryCode",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="code",
      *         in="path",
@@ -416,6 +422,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Get the latest revisions for a specific region",
      *     operationId="getLatestForRegion",
+     *     security={},
+     *     deprecated=true,
      *     @OA\Parameter(
      *         name="code",
      *         in="path",
@@ -501,6 +509,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Create a new WhatNow entity",
      *     operationId="createWhatNowEntity",
+     *     security={},
+     *     deprecated=true,
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
@@ -629,6 +639,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Update a WhatNow entity by ID",
      *     operationId="putById",
+     *     deprecated=true,
+     *     security={},
      *     @OA\Parameter(
      *         name="id",
      *         in="path",
@@ -678,22 +690,22 @@ class WhatNowController extends Controller
             ]);
         }
 
-         try {
-             $this->validate($this->request, [
-                 'countryCode' => 'alpha|size:3',
-                 'eventType' => 'string|max:50',
-                 'regionName' => 'nullable|string',
-                 'translations' => 'array',
-                 'translations.*.webUrl' => 'nullable|string',
-                 'translations.*.lang' => 'alpha|size:2',
-                 'translations.*.title' => 'string',
-                 'translations.*.description' => 'string',
-             ]);
-         } catch (ValidationException $e) {
-             Log::info($e->getMessage());
+        // try {
+        //     $this->validate($this->request, [
+        //         'countryCode' => 'alpha|size:3',
+        //         'eventType' => 'string|max:50',
+        //         'regionName' => 'nullable|string',
+        //         'translations' => 'array',
+        //         'translations.*.webUrl' => 'nullable|string',
+        //         'translations.*.lang' => 'alpha|size:2',
+        //         'translations.*.title' => 'string',
+        //         'translations.*.description' => 'string',
+        //     ]);
+        // } catch (ValidationException $e) {
+        //     Log::info($e->getMessage());
 
-             return $e->getResponse();
-         }
+        //     return $e->getResponse();
+        // }
 
         try {
             $org = $this->orgRepo->findByCountryCode($this->request->input('countryCode'));
@@ -755,6 +767,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Create a new translation for a WhatNow entity",
      *     operationId="createNewTranslation",
+     *     deprecated=true,
+     *     security={},
      *     @OA\Parameter(
      *         name="id",
      *         in="path",
@@ -844,6 +858,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Update the published status of a translation",
      *     operationId="patchTranslation",
+     *     deprecated=true,
+     *     security={},
      *     @OA\Parameter(
      *         name="id",
      *         in="path",
@@ -927,6 +943,8 @@ class WhatNowController extends Controller
      *     tags={"Whatnow"},
      *     summary="Publish translations by IDs",
      *     operationId="publishTranslationsByIds",
+     *     deprecated=true,
+     *     security={},
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(

--- a/app/Http/Controllers/WhatNowController.php
+++ b/app/Http/Controllers/WhatNowController.php
@@ -690,22 +690,22 @@ class WhatNowController extends Controller
             ]);
         }
 
-        // try {
-        //     $this->validate($this->request, [
-        //         'countryCode' => 'alpha|size:3',
-        //         'eventType' => 'string|max:50',
-        //         'regionName' => 'nullable|string',
-        //         'translations' => 'array',
-        //         'translations.*.webUrl' => 'nullable|string',
-        //         'translations.*.lang' => 'alpha|size:2',
-        //         'translations.*.title' => 'string',
-        //         'translations.*.description' => 'string',
-        //     ]);
-        // } catch (ValidationException $e) {
-        //     Log::info($e->getMessage());
+        try {
+            $this->validate($this->request, [
+                'countryCode' => 'alpha|size:3',
+                'eventType' => 'string|max:50',
+                'regionName' => 'nullable|string',
+                'translations' => 'array',
+                'translations.*.webUrl' => 'nullable|string',
+                'translations.*.lang' => 'alpha|size:2',
+                'translations.*.title' => 'string',
+                'translations.*.description' => 'string',
+            ]);
+        } catch (ValidationException $e) {
+            Log::info($e->getMessage());
 
-        //     return $e->getResponse();
-        // }
+            return $e->getResponse();
+        }
 
         try {
             $org = $this->orgRepo->findByCountryCode($this->request->input('countryCode'));

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -48,21 +48,6 @@ return [
                 ],
             ],
         ],
-        'users' => [
-            'api' => [
-                'title' => 'API Usuarios Autenticados',
-            ],
-            'routes' => [
-                'api' => 'api/users/documentation',
-            ],
-            'paths' => [
-                'docs_json' => 'users-docs.json',
-                'docs_yaml' => 'users-docs.yaml',
-                'annotations' => [
-                    base_path('app/Http/Controllers/ApiUsers'),
-                ],
-            ],
-        ],
     ],
     'defaults' => [
         'routes' => [

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -48,6 +48,21 @@ return [
                 ],
             ],
         ],
+        'users' => [
+            'api' => [
+                'title' => 'API Usuarios Autenticados',
+            ],
+            'routes' => [
+                'api' => 'api/users/documentation',
+            ],
+            'paths' => [
+                'docs_json' => 'users-docs.json',
+                'docs_yaml' => 'users-docs.yaml',
+                'annotations' => [
+                    base_path('app/Http/Controllers/ApiUsers'),
+                ],
+            ],
+        ],
     ],
     'defaults' => [
         'routes' => [
@@ -75,7 +90,6 @@ return [
              * Route Group options
              */
             'group_options' => [],
-            'security' => [['BasicAuth' => []]],
         ],
 
         'paths' => [
@@ -109,8 +123,8 @@ return [
              * @link https://zircote.github.io/swagger-php/reference/processors.html
              */
             'default_processors_configuration' => [
-            /** Example */
-            /**
+                /** Example */
+                /**
              * 'operationId.hash' => true,
              * 'pathFilter' => [
              * 'tags' => [
@@ -170,78 +184,8 @@ return [
          * API security definitions. Will be generated into documentation file.
         */
         'securityDefinitions' => [
-            'securitySchemes' => [
-                /*
-                 * Examples of Security schemes
-                 */
-                /*
-                'api_key_security_example' => [ // Unique name of security
-                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'A short description for security scheme',
-                    'name' => 'api_key', // The name of the header or query parameter to be used.
-                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
-                ],
-                'oauth2_security_example' => [ // Unique name of security
-                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'A short description for oauth2 security scheme.',
-                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
-                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
-                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
-                    'scopes' => [
-                        'read:projects' => 'read your projects',
-                        'write:projects' => 'modify projects in your account',
-                    ]
-                ],
-                */
-
-                /* Open API 3.0 support
-                'passport' => [ // Unique name of security
-                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'Laravel passport oauth2 security.',
-                    'in' => 'header',
-                    'scheme' => 'https',
-                    'flows' => [
-                        "password" => [
-                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
-                            "tokenUrl" => config('app.url') . '/oauth/token',
-                            "refreshUrl" => config('app.url') . '/token/refresh',
-                            "scopes" => []
-                        ],
-                    ],
-                ],
-                'sanctum' => [ // Unique name of security
-                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'Enter token in format (Bearer <token>)',
-                    'name' => 'Authorization', // The name of the header or query parameter to be used.
-                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
-                ],
-                */
-                'BasicAuth' => [
-                    'type' => 'http',
-                    'scheme' => 'basic'
-                ],
-                'ApiKeyAuth' => [
-                    'type' => 'apiKey',
-                    'in' => 'header',
-                    'name' => 'x-api-key',
-                ],
-            ],
-            'security' => [
-                /*
-                 * Examples of Securities
-                 */
-                [
-                    /*
-                    'oauth2_security_example' => [
-                        'read',
-                        'write'
-                    ],
-
-                    'passport' => []
-                    */
-                    'BasicAuth' => []
-                ],
-            ],
+            'securitySchemes' => [],
+            'security' => [],
         ],
 
         /*

--- a/database/migrations/2025_03_18_151133_insert_values_into_organisations.php
+++ b/database/migrations/2025_03_18_151133_insert_values_into_organisations.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+class InsertValuesIntoOrganisations extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('organisations')->insert([
+            ['country_code' => 'GLB', 'org_name' => 'Global', 'oid_code' => 'urn:oid:2.49.0.4.1', 'attribution_url' => 'https://global.org/', 'attribution_file_name' => null],
+            ['country_code' => 'AMR', 'org_name' => 'Americas', 'oid_code' => 'urn:oid:2.49.0.4.2', 'attribution_url' => 'https://americas.org/', 'attribution_file_name' => null],
+            ['country_code' => 'APC', 'org_name' => 'Asia Pacific', 'oid_code' => 'urn:oid:2.49.0.4.3', 'attribution_url' => 'https://asiapacific.org/', 'attribution_file_name' => null],
+            ['country_code' => 'MNA', 'org_name' => 'MENA', 'oid_code' => 'urn:oid:2.49.0.4.4', 'attribution_url' => 'https://mena.org/', 'attribution_file_name' => null],
+            ['country_code' => 'EUR', 'org_name' => 'Europe', 'oid_code' => 'urn:oid:2.49.0.4.5', 'attribution_url' => 'https://europe.org/', 'attribution_file_name' => null],
+            ['country_code' => 'AFR', 'org_name' => 'Africa', 'oid_code' => 'urn:oid:2.49.0.4.6', 'attribution_url' => 'https://africa.org/', 'attribution_file_name' => null],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('organisations')
+            ->whereIn('country_code', ['GLB', 'AMR', 'APC', 'MNA', 'EUR', 'AFR'])
+            ->delete();
+    }
+}

--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -114,6 +114,42 @@
             }
         </style>
     @endif
+    <style>
+            .swagger-ui .opblock .opblock-summary-path__deprecated {
+                -webkit-text-decoration: none !important;
+                text-decoration: none !important;
+            }
+            .swagger-ui .opblock .opblock-title_normal {
+                display: none !important;
+            }
+            .opblock-deprecated .try-out__btn {
+                display: none!important;
+            }
+            .swagger-ui .opblock.opblock-deprecated .opblock-summary-put .opblock-summary-method {
+                background: #fca130;
+                opacity: 0.4;
+            }
+
+            .swagger-ui .opblock.opblock-deprecated .opblock-summary-post .opblock-summary-method {
+                background: #49cc90;
+                opacity: 0.4;
+            }
+            .swagger-ui .opblock.opblock-deprecated .opblock-summary-delete .opblock-summary-method {
+                background: #f93e3e;
+                opacity: 0.4;
+            }
+
+            .swagger-ui .opblock.opblock-deprecated .opblock-summary-get .opblock-summary-method {
+                background: #61affe;
+                opacity: 0.4;
+            }
+
+            .swagger-ui .opblock.opblock-deprecated .opblock-summary-patch .opblock-summary-method {
+                background: #50e3c2;
+                opacity: 0.4;
+            }
+            
+    </style>
 </head>
 
 <body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
@@ -131,6 +167,23 @@
             configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
             validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
             oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+            supportedSubmitMethods: ['get'],
+            onComplete: function () {
+                // Crear el mensaje
+                const notice = document.createElement('div');
+                notice.innerHTML = `
+                    <div style="background: #fff3cd; color: #856404; border: 1px solid #ffeeba; padding: 15px; border-radius: 4px; margin-bottom: 20px;">
+                        🔐 <strong>Note:</strong> Only endpoints tagged as <code>Public</code> are available for testing in Swagger UI.
+                        These require an API Key (<code>X-API-KEY</code>) passed in the request header.
+                    </div>
+                `;
+
+                // Insertarlo arriba del contenido
+                const topBar = document.querySelector('.swagger-ui .info');
+                if (topBar && topBar.parentNode) {
+                    topBar.parentNode.insertBefore(notice, topBar.nextSibling);
+                }
+            },
 
             requestInterceptor: function(request) {
                 request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';

--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -134,6 +134,7 @@
 
             requestInterceptor: function(request) {
                 request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                request.headers['Accept-Language'] = 'en';
                 return request;
             },
 

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -49,7 +49,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             },
             "post": {
                 "tags": [
@@ -112,7 +114,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/apps/{id}": {
@@ -153,7 +157,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             },
             "delete": {
                 "tags": [
@@ -192,7 +198,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             },
             "patch": {
                 "tags": [
@@ -248,7 +256,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/upload": {
@@ -297,7 +307,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/org": {
@@ -305,7 +317,7 @@
                 "tags": [
                     "Organisation"
                 ],
-                "summary": "Get all organisations",
+                "summary": "Get all organisations (public)",
                 "operationId": "04f86edf4b63c5b0f297e462633924b4",
                 "responses": {
                     "200": {
@@ -339,7 +351,7 @@
                 "tags": [
                     "Organisation"
                 ],
-                "summary": "Get organisation by country code",
+                "summary": "Get organisation by country code (public)",
                 "operationId": "b4a9c9d91b102ab0d0709eae9104db61",
                 "parameters": [
                     {
@@ -477,7 +489,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/regions": {
@@ -566,7 +580,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/regions/region/{regionId}": {
@@ -658,7 +674,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             },
             "delete": {
                 "tags": [
@@ -697,7 +715,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/regions/{country_code}": {
@@ -734,7 +754,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/regions/{country_code}/{code}": {
@@ -783,7 +805,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/regions/region/translation/{translationId}": {
@@ -824,7 +848,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/usage/applications": {
@@ -875,7 +901,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/usage/endpoints": {
@@ -926,7 +954,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/usage/export": {
@@ -977,7 +1007,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/usage/totals": {
@@ -1054,7 +1086,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/whatnow/{id}": {
@@ -1062,7 +1096,7 @@
                 "tags": [
                     "Whatnow"
                 ],
-                "summary": "Obtiene un recurso publicado por ID",
+                "summary": "Obtiene un recurso publicado por ID (public)",
                 "description": "Retorna los detalles de un recurso publicado basado en el ID proporcionado.",
                 "operationId": "getPublishedById",
                 "parameters": [
@@ -1200,7 +1234,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             },
             "delete": {
                 "tags": [
@@ -1239,7 +1275,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/whatnow/{id}/revisions/latest": {
@@ -1280,7 +1318,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/org/{code}/whatnow": {
@@ -1288,7 +1328,7 @@
                 "tags": [
                     "Whatnow"
                 ],
-                "summary": "Get a feed of WhatNow entities for a specific organisation",
+                "summary": "Get a feed of WhatNow entities for a specific organisation (public)",
                 "operationId": "getFeed",
                 "parameters": [
                     {
@@ -1392,7 +1432,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/org/{code}/{region}/whatnow/revisions/latest": {
@@ -1441,7 +1483,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/whatnow": {
@@ -1531,7 +1575,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/whatnow/{id}/revisions": {
@@ -1618,7 +1664,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/whatnow/{id}/revisions/{translationId}": {
@@ -1689,7 +1737,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         },
         "/whatnow/publish": {
@@ -1741,7 +1791,9 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true,
+                "security": []
             }
         }
     },
@@ -1769,10 +1821,6 @@
     ],
     "components": {
         "securitySchemes": {
-            "BasicAuth": {
-                "type": "http",
-                "scheme": "basic"
-            },
             "ApiKeyAuth": {
                 "type": "apiKey",
                 "in": "header",


### PR DESCRIPTION
Refactored Swagger documentation for API key authentication

- Removed Basic Auth from Swagger security schemes and endpoint annotations
- Updated all public endpoints to use API Key authentication only
- Added "(public)" to the summary of API key-accessible endpoints
- Marked obsolete endpoints as deprecated and hid them via CSS (still visible in docs)
- Added a visual note at the top of the Swagger UI explaining authentication requirements
- Restricted available HTTP methods to GET only in Swagger UI using the supportedSubmitMethods option, to prevent interaction with non-public endpoints.