### PR TITLE
Bugfix/wn 322

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
         "sass": "^1.15.2",
         "sass-loader": "^7.1.0",
         "vue-template-compiler": "^2.7.16"
+    },
+    "overrides": {
+        "cipher-base": "^1.0.5",
+        "sha.js": "^2.4.12"
     }
 }


### PR DESCRIPTION
Add overrides for cipher-base and sha.js in package.json

# Security Update, Laravel Mix Dependencies

Vulnerabilities were identified in dependencies used by **laravel-mix**:

### cipher-base
- **Impact:** Affects all versions prior to `1.0.5`.  
- **Refs:**  
  - [GitHub Advisory](https://github.com/advisories/GHSA-cpq7-6gpm-g9rc)  
  - [GitLab Advisory](https://advisories.gitlab.com/pkg/npm/cipher-base/CVE-2025-9287/)  

### sha.js
- **Impact:** Vulnerability patched starting from version `2.4.12`.  
- **Refs:**  
  - [GitHub Advisory](https://github.com/advisories/GHSA-95m3-7q98-8xr5)  

### Resolution
- Updated **laravel-mix** and its transitive dependencies to include secure versions.  
- Verified that `cipher-base >= 1.0.5` and `sha.js >= 2.4.12` are correctly installed in the lockfile.  
