### PR TITLE
Enforce country restrictions for WhatNow entities

### DIFF
--- a/app/Http/Middleware/ApiAuthMiddleware.php
+++ b/app/Http/Middleware/ApiAuthMiddleware.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Models\Application;
 use App\Models\UsageLog;
+use App\Models\WhatNowEntity;
 use Carbon\Carbon;
 use Closure;
 use Illuminate\Support\Facades\Log;
@@ -87,6 +88,22 @@ class ApiAuthMiddleware extends BasicAuthMiddleware
             // If allowed_country_code is defined in rules, check if this org is restricted
             if (isset($rules['allowed_country_code']) && is_array($rules['allowed_country_code'])) {
                 if (!in_array($orgCode, $rules['allowed_country_code'])) {
+                    return false;
+                }
+            }
+        }
+
+        if (preg_match('#whatnow/(\d+)(?:/|$)#', $path, $matches) && !str_contains($path, 'org/')) {
+            if (isset($rules['allowed_country_code']) && is_array($rules['allowed_country_code'])) {
+                $whatnowId = $matches[1];
+
+                $entity = WhatNowEntity::with('organisation')->find($whatnowId);
+
+                if (!$entity || !$entity->organisation) {
+                    return false;
+                }
+
+                if (!in_array($entity->organisation->country_code, $rules['allowed_country_code'])) {
                     return false;
                 }
             }


### PR DESCRIPTION
Import WhatNowEntity and add a path-based check in ApiAuthMiddleware to enforce allowed country codes for WhatNow resources. The middleware matches requests to whatnow/{id} (excluding paths containing 'org/'), loads the WhatNowEntity with its organisation, and denies access if the entity or organisation is missing or the organisation's country_code is not listed in the rules['allowed_country_code'] array.