### PR TITLE
Filter organisations by translation published

### DIFF
--- a/app/Classes/Repositories/OrganisationRepository.php
+++ b/app/Classes/Repositories/OrganisationRepository.php
@@ -41,6 +41,19 @@ class OrganisationRepository implements OrganisationRepositoryInterface
     }
 
     /**
+     * @param bool $published
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
+    public function allByTranslationPublished($published)
+    {
+        return $this->orgModel
+            ->whereHas('details', function ($query) use ($published) {
+                $query->where('published', $published);
+            })
+            ->get();
+    }
+
+    /**
      * @param array $attributes
      * @return static
      */

--- a/app/Classes/Repositories/OrganisationRepositoryInterface.php
+++ b/app/Classes/Repositories/OrganisationRepositoryInterface.php
@@ -7,6 +7,12 @@ use App\Models\Organisation;
 interface OrganisationRepositoryInterface extends RepositoryInterface
 {
 	/**
+	 * @param bool $published
+	 * @return \Illuminate\Database\Eloquent\Collection|static[]
+	 */
+	public function allByTranslationPublished($published);
+
+	/**
 	 * @param $code
 	 * @return mixed
 	 */

--- a/app/Http/Controllers/OrganisationController.php
+++ b/app/Http/Controllers/OrganisationController.php
@@ -54,6 +54,13 @@ class OrganisationController extends Controller
      *     summary="Get all organisations (public)",
      *     security={{"ApiKeyAuth": {}}},
      *     tags={"Organisation"},
+    *     @OA\Parameter(
+    *         name="published",
+    *         in="query",
+    *         required=false,
+    *         description="Filter organisations by whether they have translations with published=true/false",
+    *         @OA\Schema(type="boolean")
+    *     ),
      *     @OA\Response(
      *         response=200,
      *         description="Successful response",
@@ -67,8 +74,27 @@ class OrganisationController extends Controller
     public function getAll(Request $request)
     {
         try {
+            $publishedParam = $request->query('published', null);
+            $publishedFilter = null;
+
+            if (!is_null($publishedParam)) {
+                $publishedFilter = filter_var($publishedParam, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+                if (is_null($publishedFilter)) {
+                    return response()->json([
+                        'status' => 422,
+                        'error_message' => 'Invalid published filter. Use true or false.',
+                        'errors' => ['published query param must be a boolean'],
+                    ], 422);
+                }
+            }
+
             /** @var Collection $orgs */
-            $orgs = $this->orgRepo->all()->load('details');
+            if (!is_null($publishedFilter)) {
+                $orgs = $this->orgRepo->allByTranslationPublished($publishedFilter)->load('details');
+            } else {
+                $orgs = $this->orgRepo->all()->load('details');
+            }
         } catch (\Exception $e) {
             Log::error('Could not get Organisations list', ['message' => $e->getMessage()]);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,8 @@ Route::group(['prefix' => config('app.api_version')], function () {
     Route::get('alerts', 'AlertController@get');
     Route::get('org/{code}/alerts', 'AlertController@getByOrg');
     Route::get('org/{code}/alerts/rss', 'AlertController@getRssByOrg');
+    Route::get('org/', 'OrganisationController@getAll');
+    Route::get('organisations', 'OrganisationController@getAll');
 });
 
 Route::group(['middleware' => 'BasicAuth', 'prefix' => config('app.api_version')], function () {
@@ -32,7 +34,6 @@ Route::group([
     'prefix' => config('app.api_version'),
 ], function () {
     // Endpoints requiring API key authentication
-    Route::get('org/', 'OrganisationController@getAll');
     Route::get('org/{code}', 'OrganisationController@getById');
     Route::get('org/{code}/whatnow', 'WhatNowController@getFeed');
     Route::get('whatnow/{id}', 'WhatNowController@getPublishedById');


### PR DESCRIPTION
Add support for filtering organisations by whether their translations are published. Implemented a new OrganisationRepository::allByTranslationPublished and declared it on the interface. OrganisationController@getAll now accepts an optional boolean ?published query param, validates it (returns 422 on invalid values), and uses the repository filter when provided; otherwise it falls back to returning all organisations. Also exposed public routes GET /org/ and GET /organisations to the controller and removed the duplicate secured route.