### PR TITLE
Update ApplicationTableSeeder.php

### DIFF
--- a/database/seeds/ApplicationTableSeeder.php
+++ b/database/seeds/ApplicationTableSeeder.php
@@ -12,13 +12,86 @@ class ApplicationTableSeeder extends Seeder
      */
     public function run()
     {
-        Application::create([
-            'tenant_id' => 1,
-            'tenant_user_id' => 1,
-            'name' => 'Test App',
-            'description' => 'App used for testing',
-            'key' => '1234'
-        ]);
+        $applications = [
+            [
+                'tenant_id' => 1,
+                'tenant_user_id' => 1,
+                'name' => 'Test App - No Rules',
+                'description' => 'App with no policy rules (full access)',
+                'key' => Application::generateKey(),
+                'is_active' => true,
+                'rules' => null,
+            ],
+            [
+                'tenant_id' => 1,
+                'tenant_user_id' => 2,
+                'name' => 'Test App - All Countries, Preparedness V2 Only',
+                'description' => 'No country restriction, legacy disabled, preparedness v2 enabled',
+                'key' => Application::generateKey(),
+                'is_active' => true,
+                'rules' => [
+                    'allowed_country_code' => [],
+                    'can_access_legacy_whatnow' => false,
+                    'can_access_preparedness_v2' => true,
+                ],
+            ],
+            [
+                'tenant_id' => 1,
+                'tenant_user_id' => 3,
+                'name' => 'IRCS WhatNow Messages',
+                'description' => 'IRCS, NHQ WhatNow Messages — India only, preparedness v2',
+                'key' => 'PYxJ6xCp2mdftP4FOj0mEDiKAqj1OulC',
+                'is_active' => true,
+                'rules' => [
+                    'allowed_country_code' => ['IND'],
+                    'can_access_legacy_whatnow' => false,
+                    'can_access_preparedness_v2' => true,
+                ],
+            ],
+            [
+                'tenant_id' => 1,
+                'tenant_user_id' => 4,
+                'name' => 'Test App - USA, Legacy + Preparedness V2',
+                'description' => 'USA only, legacy enabled, preparedness v2 enabled',
+                'key' => Application::generateKey(),
+                'is_active' => true,
+                'rules' => [
+                    'allowed_country_code' => ['USA'],
+                    'can_access_legacy_whatnow' => true,
+                    'can_access_preparedness_v2' => true,
+                ],
+            ],
+            [
+                'tenant_id' => 1,
+                'tenant_user_id' => 5,
+                'name' => 'Test App - All Countries, Legacy + Preparedness V2',
+                'description' => 'No country restriction, legacy enabled, preparedness v2 enabled',
+                'key' => Application::generateKey(),
+                'is_active' => true,
+                'rules' => [
+                    'allowed_country_code' => [],
+                    'can_access_legacy_whatnow' => true,
+                    'can_access_preparedness_v2' => true,
+                ],
+            ],
+            [
+                'tenant_id' => 1,
+                'tenant_user_id' => 6,
+                'name' => 'Test App - USA, Legacy Only',
+                'description' => 'USA only, legacy enabled, preparedness v2 disabled',
+                'key' => Application::generateKey(),
+                'is_active' => true,
+                'rules' => [
+                    'allowed_country_code' => ['USA'],
+                    'can_access_legacy_whatnow' => true,
+                    'can_access_preparedness_v2' => false,
+                ],
+            ],
+        ];
+
+        foreach ($applications as $data) {
+            Application::create($data);
+        }
     }
 }
 


### PR DESCRIPTION
This pull request expands the seeding logic in `ApplicationTableSeeder` to create multiple test application records with varying access rules and configurations. Instead of seeding a single application, the seeder now adds a diverse set of applications to better support testing different scenarios.

Key changes:

**Seeding logic improvements:**

* Replaces the single static `Application::create` call with a loop that seeds six different application records, each with distinct `name`, `description`, `tenant_user_id`, and access `rules`.

**Test data diversity:**

* Adds applications covering scenarios such as: no policy rules (full access), all countries with only preparedness v2 enabled, India-only access, USA-only access with legacy and/or preparedness v2 enabled, and combinations thereof.
* Some applications use dynamically generated keys via `Application::generateKey()`, while one uses a static key for testing purposes.
* Each application record now includes an `is_active` flag and a `rules` array to control access restrictions and feature toggles.