### PR TITLE
Rename WhatNow API routes to preparemessages

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -35,8 +35,8 @@ Route::group([
 ], function () {
     // Endpoints requiring API key authentication
     Route::get('org/{code}', 'OrganisationController@getById');
-    Route::get('org/{code}/whatnow', 'WhatNowController@getFeed');
-    Route::get('whatnow/{id}', 'WhatNowController@getPublishedById');
+    Route::get('org/{code}/preparemessages', 'WhatNowController@getFeed');
+    Route::get('preparemessages/{id}', 'WhatNowController@getPublishedById');
 });
 
 Route::group([


### PR DESCRIPTION
Change API endpoints from /org/{code}/whatnow and /whatnow/{id} to /org/{code}/preparemessages and /preparemessages/{id} to better reflect their purpose; controller actions remain the same. Also remove an extraneous blank line in WhatNowRepository.php.