### PR TITLE
Set default rules when creating Application

### DIFF
--- a/app/Classes/Repositories/ApplicationRepository.php
+++ b/app/Classes/Repositories/ApplicationRepository.php
@@ -54,6 +54,11 @@ class ApplicationRepository implements ApplicationRepositoryInterface
     public function create(array $attributes)
     {
         $attributes['key'] = Application::generateKey();
+        $attributes['rules'] = array_merge([
+            'can_access_legacy_whatnow' => true,
+            'can_access_preparedness_v2' => false,
+            'allowed_country_code' => [],
+        ], $attributes['rules'] ?? []);
 
         return $this->applicationModel->create($attributes);
     }


### PR DESCRIPTION
Merge default rule values into attributes['rules'] on Application creation to ensure required keys are present. Adds defaults: can_access_legacy_whatnow = true, can_access_preparedness_v2 = false, allowed_country_code = []. Defaults are merged with any provided rules so callers can override them; existing key generation behavior is unchanged.