### PR TITLE
Only enforce org check for v2 API

### DIFF
--- a/app/Http/Middleware/ApiAuthMiddleware.php
+++ b/app/Http/Middleware/ApiAuthMiddleware.php
@@ -44,7 +44,10 @@ class ApiAuthMiddleware extends BasicAuthMiddleware
                 return response()->json(['error' => 'Application is not allowed to access this API version'], 403);
             }
 
-            $canAccessOrganisation = $this->canAccessOrganisation($request->path(), (array) $application->rules);
+            $canAccessOrganisation = true;
+            if (strpos($request->path(), 'v2/') === 0) {
+                $canAccessOrganisation = $this->canAccessOrganisation($request->path(), (array) $application->rules);
+            }
 
             if (!$canAccessOrganisation) {
                 return response()->json(['error' => 'Application is not allowed to access this organisation'], 403);


### PR DESCRIPTION
Make organisation access enforcement conditional on API version by defaulting $canAccessOrganisation to true and only calling canAccessOrganisation() for paths starting with 'v2/'. This avoids applying organisation-level rules to non-v2 endpoints and prevents unnecessary 403 responses for older API versions.